### PR TITLE
Julia 1.0 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,11 @@ os:
   - linux
   - osx
 julia:
+  - 1.0
+  - 1.1
   - 1.2
   - 1.3
+  - 1.4
   - nightly
 notifications:
   email: false

--- a/Project.toml
+++ b/Project.toml
@@ -3,14 +3,12 @@ uuid = "3c3547ce-8d99-4f5e-a174-61eb10b00ae3"
 authors = ["Fabian Gans <fgans@bgc-jena.mpg.de>"]
 version = "0.1.1"
 
-[deps]
+[compat]
+julia = "1.0"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test","Statistics"]
-
-[compat]
-julia = "1.2"
+test = ["Test", "Statistics"]

--- a/src/DiskArrays.jl
+++ b/src/DiskArrays.jl
@@ -198,11 +198,13 @@ macro implement_diskarray(t)
 quote
   @implement_getindex $t
   @implement_setindex $t
-  @implement_broadcast $t
-  @implement_iteration $t
-  @implement_mapreduce $t
-  @implement_reshape $t
-  @implement_permutedims $t
+  if VERSION >= v"1.3.0"
+    @implement_broadcast $t
+    @implement_iteration $t
+    @implement_mapreduce $t
+    @implement_reshape $t
+    @implement_permutedims $t
+  end
 end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -171,6 +171,8 @@ end
   test_view(a)
 end
 
+# The remaing tests only work for Julia >= 1.3
+if VERSION >= v"1.3.0"
 import Statistics: mean
 @testset "Reductions" begin
   a = data -> _DiskArray(data,chunksize=(5,4,2))
@@ -205,4 +207,5 @@ import Base.PermutedDimsArrays.invperm
   test_view(a)
   a = data -> permutedims(_DiskArray(permutedims(data,ip),chunksize=(4,2,5)),p)
   test_reductions(a)
+end
 end


### PR DESCRIPTION
Enable broadcasting and Reductions only for Julia 1.2+, but have indexing work for all Julia versions starting from 1.0