### PR TITLE
Allow indexing with Vector along a dimension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiskArrays"
 uuid = "3c3547ce-8d99-4f5e-a174-61eb10b00ae3"
 authors = ["Fabian Gans <fgans@bgc-jena.mpg.de>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [compat]
 julia = "1.0"

--- a/README.md
+++ b/README.md
@@ -158,4 +158,7 @@ Reading at index Base.OneTo(10) Base.OneTo(9) 1:1
 
 ## Accessing strided Arrays
 
-One
+There are situations where one wants to read every other value along a certain axis or provide arbitrary strides. Some DiskArray backends may want to provide optimized methods to read these strided arrays. 
+In this case a backend can define `readblock!(a,aout,r::OrdinalRange...)` and the respective `writeblock`
+method which will overwrite the fallback behavior that would read the whol block of data and only return
+the desired range.

--- a/src/DiskArrays.jl
+++ b/src/DiskArrays.jl
@@ -25,7 +25,7 @@ should be supported as well.
 """
 function writeblock!() end
 
-function readblock!(A::AbstractDiskArray, A_ret, r::OrdinalRange...)
+function readblock!(A::AbstractDiskArray, A_ret, r::AbstractVector...)
   #Implement fallback method if DiskArray does not support strided reading
   #Currently this allocates an intermediate array. In the future, this
   #function could test how sparse the reading is and maybe be smarter here
@@ -37,7 +37,7 @@ function readblock!(A::AbstractDiskArray, A_ret, r::OrdinalRange...)
   nothing
 end
 
-function writeblock!(A::AbstractDiskArray, A_ret, r::OrdinalRange...)
+function writeblock!(A::AbstractDiskArray, A_ret, r::AbstractVector...)
   #Implement fallback method if DiskArray does not support strided reading
   #Currently this allocates an intermediate array. In the future, this
   #function could test how sparse the reading is and maybe be smarter here
@@ -99,7 +99,7 @@ interpret_indices_disk(A, r::Tuple{<:CartesianIndices}) =
 
 
 
-function interpret_indices_disk(A, r::NTuple{N, Union{Integer, OrdinalRange, Colon}}) where N
+function interpret_indices_disk(A, r::NTuple{N, Union{Integer, AbstractVector, Colon}}) where N
   if ndims(A)==N
     inds = map(_convert_index,r,size(A))
     resh = DimsDropper(findints(r))
@@ -173,7 +173,7 @@ _findints(c, i, x, rest...) = _findints(c, i+1, rest...)
 _findints(c, i)  = c
 #Normal indexing for a full subset of an array
 _convert_index(i::Integer, s::Integer) = i:i
-_convert_index(i::OrdinalRange, s::Integer) = i
+_convert_index(i::AbstractVector, s::Integer) = i
 _convert_index(::Colon, s::Integer) = Base.OneTo(Int(s))
 
 macro implement_getindex(t)

--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -24,7 +24,7 @@ Base.size(g::GridChunks) = g.chunkgridsize
 Base.size(g::GridChunks, dim) = g.chunkgridsize[dim]
 Base.IteratorSize(::Type{GridChunks{N}}) where N = Base.HasShape{N}()
 Base.eltype(::Type{GridChunks{N}}) where N = CartesianIndices{N,NTuple{N,UnitRange{Int64}}}
-Base.length(c) = prod(size(c))
+Base.length(c::GridChunks) = prod(size(c))
 @inline function _iterate(g,r)
     if r === nothing
         return nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,12 +45,13 @@ function test_getindex(a)
   @test a[1:2, 1:2,1,1] == [1 5; 2 6]
   @test a[2:2:4,1:2:5] == [2 10 18; 4 12 20]
   @test a[end:-1:1,1,1] == [4,3,2,1]
+  @test a[[1,3,4],[1,3],1] == [1 9; 3 11; 4 12]
   # Test bitmask indexing
   m = falses(4,5,1)
   m[2,:,1] .= true
   @test a[m] == [2,6,10,14,18]
   #Test that readblock was called exactly onces for every getindex
-  @test getindex_count(a) == 8
+  @test getindex_count(a) == 9
 end
 
 function test_setindex(a)
@@ -72,6 +73,9 @@ function test_setindex(a)
   a[1:2:4,1:2:5,1] = [1 2 3; 5 6 7]
   @test trueparent(a)[1:2:4,1:2:5,1] == [1 2 3; 5 6 7]
   @test setindex_count(a) == 7
+  a[[2,4],1:2,1] = [1 2; 5 6]
+  @test trueparent(a)[[2,4],1:2,1] == [1 2; 5 6]
+  @test setindex_count(a) == 8
 end
 
 function test_view(a)


### PR DESCRIPTION
This relaxes the method signature for the fallback `readblock!` even more, so that more indexing styles are supported. 