### PR TITLE
Add a setindex method for arrays of arrays

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,8 @@ os:
   - linux
   - osx
 julia:
-  - 1.0
-  - 1.1
+  - 1
   - 1.2
-  - 1.3
-  - 1.4
   - nightly
 notifications:
   email: false

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiskArrays"
 uuid = "3c3547ce-8d99-4f5e-a174-61eb10b00ae3"
 authors = ["Fabian Gans <fgans@bgc-jena.mpg.de>"]
-version = "0.2.4"
+version = "0.2.5"
 
 [compat]
 julia = "1.0"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 environment:
   matrix:
   - julia_version: 1
+  - julia_version: 1.2
   - julia_version: nightly
 
 platform:

--- a/src/DiskArrays.jl
+++ b/src/DiskArrays.jl
@@ -60,6 +60,10 @@ function getindex_disk(a, i...)
   readblock!(a,data,inds...)
   trans(data)
 end
+
+setindex_disk!(a::AbstractDiskArray{T},v::T,i...) where T<:AbstractArray = 
+  setindex_disk!(a,[v],i...)
+  
 function setindex_disk!(a::AbstractDiskArray,v::AbstractArray,i...)
   inds, trans = interpret_indices_disk(a,i)
   data = reshape(v,map(length,inds))

--- a/src/subarrays.jl
+++ b/src/subarrays.jl
@@ -22,6 +22,7 @@ function writeblock!(a::SubDiskArray,v,i::OrdinalRange...)
 end
 Base.size(a::SubDiskArray) = size(a.v)
 eachchunk(a::SubDiskArray) = eachchunk_view(haschunks(a.v.parent),a.v)
+Base.parent(a::SubDiskArray) = a.v.parent
 function eachchunk_view(::Chunked, vv)
   pinds = parentindices(vv)
   iomit = findints(pinds)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -156,12 +156,12 @@ end
 @testset "Index interpretation" begin
   import DiskArrays: DimsDropper, Reshaper
   a = zeros(3,3,1)
-  @test interpret_indices_disk(a, (:,2,:)) == ((Base.OneTo(3), 2:2, Base.OneTo(1)), DimsDropper{Tuple{Int64}}((2,)))
-  @test interpret_indices_disk(a, (1,2,:)) == ((1:1, 2:2, Base.OneTo(1)), DimsDropper{Tuple{Int64,Int64}}((1, 2)))
-  @test interpret_indices_disk(a, (1,2,2,1)) == ((1:1, 2:2, 2:2), DimsDropper{Tuple{Int64,Int64,Int64}}((1, 2, 3)))
-  @test interpret_indices_disk(a, (1,2,2,1)) == ((1:1, 2:2, 2:2), DimsDropper{Tuple{Int64,Int64,Int64}}((1, 2, 3)))
-  @test interpret_indices_disk(a, (:,1:2)) == ((Base.OneTo(3), 1:2, 1:1), DimsDropper{Tuple{Int64}}((3,)))
-  @test interpret_indices_disk(a, (:,)) == ((Base.OneTo(3), Base.OneTo(3), Base.OneTo(1)), DiskArrays.Reshaper{Int64}(9))
+  @test interpret_indices_disk(a, (:,2,:)) == ((Base.OneTo(3), 2:2, Base.OneTo(1)), DimsDropper{Tuple{Int}}((2,)))
+  @test interpret_indices_disk(a, (1,2,:)) == ((1:1, 2:2, Base.OneTo(1)), DimsDropper{Tuple{Int,Int}}((1, 2)))
+  @test interpret_indices_disk(a, (1,2,2,1)) == ((1:1, 2:2, 2:2), DimsDropper{Tuple{Int,Int,Int}}((1, 2, 3)))
+  @test interpret_indices_disk(a, (1,2,2,1)) == ((1:1, 2:2, 2:2), DimsDropper{Tuple{Int,Int,Int}}((1, 2, 3)))
+  @test interpret_indices_disk(a, (:,1:2)) == ((Base.OneTo(3), 1:2, 1:1), DimsDropper{Tuple{Int}}((3,)))
+  @test interpret_indices_disk(a, (:,)) == ((Base.OneTo(3), Base.OneTo(3), Base.OneTo(1)), DiskArrays.Reshaper{Int}(9))
 end
 
 @testset "AbstractDiskArray getindex" begin


### PR DESCRIPTION
This adds a setindex method which is useful when dealing with array of arrays. This was throwing an error before, so should be non-brekaing. 