### PR TITLE
use closures for eachchunk

### DIFF
--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -59,6 +59,7 @@ const fallback_element_size = Ref(100)
 #Here we implement a fallback chunking for a DiskArray although this should normally
 #be over-ridden by the package that implements the interface
 
+eachchunk(f, a::AbstractArray) = f(eachchunk(a))
 function eachchunk(a::AbstractArray)
   cs = estimate_chunksize(a)
   GridChunks(a,cs)

--- a/src/permute_reshape.jl
+++ b/src/permute_reshape.jl
@@ -10,18 +10,19 @@ struct ReshapedDiskArray{T,N,P<:AbstractArray,M} <: AbstractDiskArray{T,N}
 end
 Base.size(r::ReshapedDiskArray) = r.newsize
 haschunks(a::ReshapedDiskArray) = haschunks(a.parent)
-function eachchunk(a::ReshapedDiskArray{<:Any,N}) where N
-  pchunks = eachchunk(a.parent)
-  inow::Int=0
-  outchunks = ntuple(N) do idim
-    if in(idim,a.keepdim)
-      inow+=1
-      pchunks.chunksize[inow],pchunks.offset[inow]
-    else
-      (1,0)
-    end
+function eachchunk(f, a::ReshapedDiskArray{<:Any,N}) where N
+  eachchunk(f, a.parent) do pchunks 
+      inow::Int=0
+      outchunks = ntuple(N) do idim
+        if in(idim,a.keepdim)
+          inow+=1
+          pchunks.chunksize[inow],pchunks.offset[inow]
+        else
+          (1,0)
+        end
+      end
+      GridChunks(a,first.(outchunks), offset=last.(outchunks))
   end
-  GridChunks(a,first.(outchunks), offset=last.(outchunks))
 end
 
 function DiskArrays.readblock!(a::ReshapedDiskArray,aout,i::OrdinalRange...)


### PR DESCRIPTION
In GeoData.jl I try to keep files closed and open them only when data is needed, as e.g. ArchGDAL is mostly intended to be used (You can use `open` with a closure to to operate on the held-open file).

My problem is `eachchunk` doesn't work with this approach, because the file is not yet open when it is called, there is not way of returning multiple chunks over a single open file that allows closing the file again afterwards.

Something like this can achieve that, and is all this PR does:

```julia
echchunk(f, A)
```

where `f` is the function DiskArrays wants to have applied to the object, such as a broadcast.

The fallback is:

```julia
eachchunk(f, A) = f(eachchunk(A))
```
So that current implementations are not affected by the change.

I'll add some tests for this later, I'm currently just spitballing the idea and this was very quick to put together.