### PR TITLE
fix common_chunks for last axis length 1

### DIFF
--- a/src/ops.jl
+++ b/src/ops.jl
@@ -52,7 +52,7 @@ function common_chunks(s,args...)
     allcs = map(ar->(eachchunk(ar).chunksize,eachchunk(ar).offset),chunkedars)
     tt = ntuple(N) do n
       csnow = filter(cs->length(cs[1])>=n && cs[1][n]>1,allcs)
-      isempty(csnow) && return 1
+      isempty(csnow) && return (1, 0)
       cs = (csnow[1][1][n],csnow[1][2][n])
       all(s->(s[1][n],s[2][n]) == cs,csnow) || error("Chunks do not align in dimension $n")
       return cs

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -203,6 +203,14 @@ end
   test_broadcast(a_disk1)
 end
 
+@testset "Broadcast with length 1 final dim" begin
+  a_disk1 = _DiskArray(rand(10,9,1), chunksize=(5,3,1))
+  a_disk2 = _DiskArray(rand(1:10,1,9), chunksize=(1,3))
+  s = a_disk1 .+ a_disk2
+  @test DiskArrays.eachchunk(s) isa DiskArrays.GridChunks{3}
+  @test size(collect(s)) == (10, 9, 1)
+end
+
 @testset "Reshape" begin
   a = reshape(_DiskArray(reshape(1:20,4,5)),4,5,1)
   test_getindex(a)


### PR DESCRIPTION
Seems that this was only broken when the final axis length is 1 for one of the arrays, so I added a new test block to catch this specifically.