### PR TITLE
fix ReshapeDiskArray and PermutDiskArray constructors

### DIFF
--- a/src/permute_reshape.jl
+++ b/src/permute_reshape.jl
@@ -3,7 +3,7 @@ import DiskArrays: splittuple
 #Reshaping is really not trivial, because the access pattern would completely change for reshaped arrays,
 #rectangles would not remain rectangles in the parent array. However, we can support the case where only
 #singleton dimensions are added, later we could allow more special cases like joining two dimensions to one
-struct ReshapedDiskArray{T,N,P<:AbstractArray,M} <: AbstractDiskArray{T,N}
+struct ReshapedDiskArray{T,N,P<:AbstractArray{T},M} <: AbstractDiskArray{T,N}
     parent::P
     keepdim::NTuple{M,Int}
     newsize::NTuple{N,Int}
@@ -58,7 +58,7 @@ end
 
 import Base: _throw_dmrs
 import Base.PermutedDimsArrays: genperm
-struct PermutedDiskArray{T,N,P<:PermutedDimsArray} <: AbstractDiskArray{T,N}
+struct PermutedDiskArray{T,N,P<:PermutedDimsArray{T,N}} <: AbstractDiskArray{T,N}
     a::P
 end
 function permutedims_disk(a,perm)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -225,6 +225,8 @@ end
   test_view(a)
   a = data -> reshape(_DiskArray(data,chunksize=(5,4,2)),10,20,2,1)
   test_reductions(a)
+  a = reshape(_DiskArray(reshape(1:20,4,5)),4,5,1)
+  @test ReshapedDiskArray(a.parent, a.keepdim, a.newsize) === a
 end
 
 import Base.PermutedDimsArrays.invperm
@@ -241,6 +243,7 @@ import Base.PermutedDimsArrays.invperm
   test_reductions(a)
   a_disk1 = permutedims(_DiskArray(rand(9,2,10), chunksize=(3,2,5)),p)
   test_broadcast(a_disk1)
+  @test PermutedDiskArray(a_disk1.a) === a_disk1
 end
 
 @testset "Unchunked String arrays" begin


### PR DESCRIPTION
This is a tiny PR just to fix the behavior of these constructors. Currently they can't be reconstructed from their fields, which makes them hard to reconstruct with new contents.

