### PR TITLE
fix broadcast for iterables like Ref and Tuple

### DIFF
--- a/src/ops.jl
+++ b/src/ops.jl
@@ -60,7 +60,7 @@ function common_chunks(s,args...)
     return map(i->i[1],tt),map(i->i[2],tt)
   end
 end
-subsetarg(x::Number,a) = x
+subsetarg(x, a) = x
 function subsetarg(x::AbstractArray,a)
   ashort = maybeonerange(size(x),a)
   view(x,ashort...) #Maybe making a copy here would be faster, need to check...

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -121,7 +121,7 @@ function test_broadcast(a_disk1)
   a_disk2 = _DiskArray(rand(1:10,1,9), chunksize=(1,3))
   a_mem   = reshape(1:2,1,1,2);
 
-  s = a_disk1 .+ a_disk2
+  s = a_disk1 .+ a_disk2 .* Ref(2) ./ (2,)
   #Test lazy broadcasting
   @test s isa DiskArrays.BroadcastDiskArray
   @test getindex_count(a_disk1)==0
@@ -139,7 +139,7 @@ function test_broadcast(a_disk1)
   @test eltype(s) == Float64
   #And now do the computation with Array as a sink
   aout = zeros(10,9,2)
-  aout .= s2
+  aout .= s2 .* 2 ./ Ref(2)
   #Test if the result is correct
   @test aout == (trueparent(a_disk1) .+ trueparent(a_disk2))./a_mem
   @test getindex_count(a_disk1)==6


### PR DESCRIPTION
Currently broadcast with `Ref` or `Tuple` does not work.

The fix is trivial: to free the type in `subsetarg(x::Number, x) = x` from `Number` to `Any`. I'm not totally accross what `subsetarg` is for but this seems to work.