### PR TITLE
add method for Array, copyto, reverse where the fallbacks are broken

### DIFF
--- a/src/DiskArrays.jl
+++ b/src/DiskArrays.jl
@@ -227,6 +227,7 @@ function Base.show(io::IO, X::AbstractDiskArray)
   println(io, "Disk Array with size ", join(size(X)," x "))
 end
 
+include("array.jl")
 include("chunks.jl")
 include("ops.jl")
 include("iterator.jl")
@@ -243,6 +244,7 @@ quote
     @implement_iteration $t
     @implement_mapreduce $t
     @implement_reshape $t
+    @implement_array_methods $t
     @implement_permutedims $t
   end
 end

--- a/src/array.jl
+++ b/src/array.jl
@@ -15,16 +15,34 @@ macro implement_array_methods(t)
             DiskArrays._copyto!(dest, Rdest, src, Rsrc)
         end
         Base.reverse(a::$t, dims=:) = DiskArrays._reverse(a, dims)
+        # Here we extend the unexported `_replace` method, but we replicate 
+        # much less Base functionality by extending it rather than `replace`.
+        function Base._replace!(new::Base.Callable, res::AbstractArray, A::$t, count::Int)
+            DiskArrays._replace!(new, res, A, count)
+        end
+        function Base._replace!(new::Base.Callable, res::$t, A::AbstractArray, count::Int)
+            DiskArrays._replace!(new, res, A, count)
+        end
+        function Base._replace!(new::Base.Callable, res::$t, A::$t, count::Int)
+            DiskArrays._replace!(new, res, A, count)
+        end
     end
 end
 
+# Use broadcast to copy to a new Array
 function _Array(a::AbstractArray{T,N}) where {T,N}
     dest = Array{T,N}(undef, size(a))
     dest .= a
     return dest
 end
 
-_copyto!(dest, source) = dest .= source
+# Use broadcast to copy
+_copyto!(dest::AbstractArray{<:Any,N}, source::AbstractArray{<:Any,N}) where N = dest .= source
+function _copyto!(dest::AbstractArray, source::AbstractArray)
+    # TODO make this more specific so we are reshaping the Non-DiskArray more often.
+    reshape(dest, size(source)) .= source
+    return dest
+end
 _copyto!(dest, Rdest, src, Rsrc) = view(dest, Rdest) .= view(src, Rsrc)
 
 # Use a view for lazy reverse
@@ -36,4 +54,11 @@ function _reverse(A, dims::Tuple)
         d in dims ? reverse(ax) : ax
     end
     return view(A, rev_axes...)
+end
+
+# Use broadcast instead of a loop. 
+# The `count` argument is disallowed as broadcast is not sequential.
+function _replace!(new, res::AbstractArray, A::AbstractArray, count::Int)
+    count < length(res) && throw(ArgumentError("`replace` on DiskArrays objects cannot use a count value"))
+    broadcast!(new, res, A)
 end

--- a/src/array.jl
+++ b/src/array.jl
@@ -1,0 +1,39 @@
+
+macro implement_array_methods(t)
+    quote
+        Base.Array(a::$t) = DiskArrays._Array(a)
+        Base.copyto!(dest::$t, source::AbstractArray) = DiskArrays._copyto!(dest, source)
+        Base.copyto!(dest::AbstractArray, source::$t) = DiskArrays._copyto!(dest, source)
+        Base.copyto!(dest::$t, source::$t) = DiskArrays._copyto!(dest, source)
+        function Base.copyto!(dest::$t, Rdest::CartesianIndices, src::AbstractArray, Rsrc::CartesianIndices)
+            DiskArrays._copyto!(dest, Rdest, src, Rsrc)
+        end
+        function Base.copyto!(dest::AbstractArray, Rdest::CartesianIndices, src::$t, Rsrc::CartesianIndices)
+            DiskArrays._copyto!(dest, Rdest, src, Rsrc)
+        end
+        function Base.copyto!(dest::$t, Rdest::CartesianIndices, src::$t, Rsrc::CartesianIndices)
+            DiskArrays._copyto!(dest, Rdest, src, Rsrc)
+        end
+        Base.reverse(a::$t, dims=:) = DiskArrays._reverse(a, dims)
+    end
+end
+
+function _Array(a::AbstractArray{T,N}) where {T,N}
+    dest = Array{T,N}(undef, size(a))
+    dest .= a
+    return dest
+end
+
+_copyto!(dest, source) = dest .= source
+_copyto!(dest, Rdest, src, Rsrc) = view(dest, Rdest) .= view(src, Rsrc)
+
+# Use a view for lazy reverse
+_reverse(a, dims::Colon) = _reverse(a, ntuple(identity, ndims(a)))
+_reverse(a, dims::Int) = _reverse(a, (dims,))
+function _reverse(A, dims::Tuple)
+    rev_axes = map(ntuple(identity, ndims(A)), axes(A)) do d, a
+        ax = StepRange(a)
+        d in dims ? reverse(ax) : ax
+    end
+    return view(A, rev_axes...)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using DiskArrays
 using DiskArrays: ReshapedDiskArray, PermutedDiskArray
 using Test
+using Statistics
 
 #Define a data structure that can be used for testing
 struct _DiskArray{T,N,A<:AbstractArray{T,N}} <: AbstractDiskArray{T,N}
@@ -228,15 +229,23 @@ end
       copyto!(x, CartesianIndices((1:3, 1:2)), a_disk, CartesianIndices((8:10, 8:9)))
   end
 
-  @testset "reverse" begin
-      @test collect(reverse(a_disk)) == reverse(a)
-      @test collect(reverse(a_disk; dims=2)) == reverse(a; dims=2)
-      @test collect(rotl90(a_disk)) == rotl90(a)
-      @test collect(rot180(a_disk)) == rot180(a)
-      @test collect(rotr90(a_disk)) == rotr90(a)
-  end
-
-  @test_broken vcat(a_disk, a_disk)
+  @test collect(reverse(a_disk)) == reverse(a)
+  @test collect(reverse(a_disk; dims=2)) == reverse(a; dims=2)
+  @test replace(a_disk, 1=>2) == replace(a, 1=>2)
+  @test rotr90(a_disk) == rotr90(a)
+  @test rotl90(a_disk) == rotl90(a)
+  @test rot180(a_disk) == rot180(a)
+  @test extrema(a_disk) == extrema(a)
+  @test mean(a_disk) == mean(a)
+  @test mean(a_disk; dims=1) == mean(a; dims=1)
+  @test std(a_disk) == std(a)
+  @test median(a_disk) == median(a)
+  @test median(a_disk; dims=1) == median(a; dims=1) # Works but very slow
+  @test median(a_disk; dims=2) == median(a; dims=2) # Works but very slow
+  @test_broken vcat(a_disk, a_disk) == vcat(a, a) # Wrong answer because `iterate` is broken
+  @test_broken hcat(a_disk, a_disk) == hcat(a, a) # Wrong answer because `iterate` is broken
+  @test_broken cat(a_disk, a_disk; dims=3) == cat(a, a; dims=3) # Wrong answer because `iterate` is broken
+  @test_broken circshift(a_disk, 2) == circshift(a, 2) # This one is super weird. The size changes.
 end
 
 @testset "Reshape" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -217,6 +217,28 @@ end
   @test size(collect(s)) == (10, 9, 1)
 end
 
+@testset "Array methods" begin
+  a = collect(reshape(1:90,10,9))
+  a_disk = _DiskArray(a, chunksize=(5,3))
+  @test collect(a_disk) == a
+  @test Array(a_disk) == a
+  @testset "copyto" begin
+      x = zero(a); copyto!(x, a_disk)
+      @test x == a
+      copyto!(x, CartesianIndices((1:3, 1:2)), a_disk, CartesianIndices((8:10, 8:9)))
+  end
+
+  @testset "reverse" begin
+      @test collect(reverse(a_disk)) == reverse(a)
+      @test collect(reverse(a_disk; dims=2)) == reverse(a; dims=2)
+      @test collect(rotl90(a_disk)) == rotl90(a)
+      @test collect(rot180(a_disk)) == rot180(a)
+      @test collect(rotr90(a_disk)) == rotr90(a)
+  end
+
+  @test_broken vcat(a_disk, a_disk)
+end
+
 @testset "Reshape" begin
   a = reshape(_DiskArray(reshape(1:20,4,5)),4,5,1)
   test_getindex(a)


### PR DESCRIPTION
This PR adds a few more base array methods - `Array`, `copyto!` and `reverse` that are currently broken with chunks and the fallback implementation. `Array` and `copyto` use broadcast `=`, while `reverse` uses `view`.

Also `replace` uses broadcast instead of a loop, which means that `count` doesn't work, but that is not a common use case anyway.