### PR TITLE
fix reshape with existing trailing 1s

### DIFF
--- a/src/permute_reshape.jl
+++ b/src/permute_reshape.jl
@@ -42,14 +42,16 @@ function reshape_disk(parent, dims)
     ndims(parent) > length(dims) && error("For DiskArrays, reshape is restricted to adding singleton dimensions")
     prod(dims) == n || _throw_dmrs(n, "size", dims)
     ipassed::Int=0
-    s = size(parent)
-    keepdim = map(s) do snow
+    keepdim = map(size(parent)) do s
         while true
             ipassed += 1
             d = dims[ipassed]
             if d>1
-                d != snow && error("For DiskArrays, reshape is restricted to adding singleton dimensions")
+                d != s && error("For DiskArrays, reshape is restricted to adding singleton dimensions")
                 return ipassed
+            else
+                # For existing trailing 1s
+                d == s == 1 && return ipassed
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -259,6 +259,9 @@ end
   test_reductions(a)
   a = reshape(_DiskArray(reshape(1:20,4,5)),4,5,1)
   @test ReshapedDiskArray(a.parent, a.keepdim, a.newsize) === a
+  # Reshape with existing trailing 1s works
+  a = reshape(_DiskArray(reshape(1:100,5,5,2,2,1,1)),5,5,2,2,1,1,1)
+  @test a[5,5,2,2,1,1,1] == 100
 end
 
 import Base.PermutedDimsArrays.invperm


### PR DESCRIPTION
Fixes reshape breaking when there are existing trailing 1s in the array.

See: https://github.com/rafaqz/Rasters.jl/issues/234

