### PR TITLE
Redesign of GridChunks type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.3' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
+          - '1.6' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
           - '1' # Leave this line unchanged. '1' will automatically expand to the latest stable 1.x release of Julia.
           - 'nightly'
         os:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.2' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
+          - '1.3' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
           - '1' # Leave this line unchanged. '1' will automatically expand to the latest stable 1.x release of Julia.
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ authors = ["Fabian Gans <fgans@bgc-jena.mpg.de>"]
 version = "0.3.0"
 
 [compat]
-julia = "1.0"
+julia = "1.6"
 
 [extras]
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiskArrays"
 uuid = "3c3547ce-8d99-4f5e-a174-61eb10b00ae3"
 authors = ["Fabian Gans <fgans@bgc-jena.mpg.de>"]
-version = "0.2.13"
+version = "0.3.0"
 
 [compat]
 julia = "1.0"

--- a/src/DiskArrays.jl
+++ b/src/DiskArrays.jl
@@ -239,14 +239,12 @@ macro implement_diskarray(t)
 quote
   @implement_getindex $t
   @implement_setindex $t
-  if VERSION >= v"1.3.0"
-    @implement_broadcast $t
-    @implement_iteration $t
-    @implement_mapreduce $t
-    @implement_reshape $t
-    @implement_array_methods $t
-    @implement_permutedims $t
-  end
+  @implement_broadcast $t
+  @implement_iteration $t
+  @implement_mapreduce $t
+  @implement_reshape $t
+  @implement_array_methods $t
+  @implement_permutedims $t
 end
 end
 

--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -27,7 +27,12 @@ Base.size(r::RegularChunks) = (size(r,1),)
 function subsetchunks(r::RegularChunks, subs::AbstractUnitRange)
   snew = length(subs)
   newoffset = mod(first(subs)-1+r.offset,r.cs)
-  RegularChunks(r.cs, newoffset, snew)
+  r = RegularChunks(r.cs, newoffset, snew)
+  #In case the new chunk is trivial and has length 1, we shorten the chunk size
+  if length(r) == 1
+    r = RegularChunks(snew, 0, snew)
+  end
+  r
 end
 function subsetchunks(r::RegularChunks, subs::AbstractRange)
   #This is a method only to make "reverse" work and should error for all other cases

--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -5,45 +5,95 @@ Returns an iterator with `CartesianIndices` elements that mark the index range o
 """
 function eachchunk end
 
-struct GridChunks{N}
-    parentsize::NTuple{N,Int}
-    chunksize::NTuple{N,Int}
-    chunkgridsize::NTuple{N,Int}
-    offset::NTuple{N,Int}
+abstract type ChunkType <: AbstractVector{UnitRange} end
+
+"""
+    RegularChunks
+
+Defines chunking along a dimension where the chunks have constant size and a potential
+offset for the first chunk. The last chunk is truncated to fit the array size. 
+"""
+struct RegularChunks <: ChunkType
+    cs::Int
+    offset::Int
+    s::Int
 end
-GridChunks(a, chunksize; offset = (_->0).(size(a))) = GridChunks(Int.(size(a)), Int.(chunksize), Int.(getgridsize(size(a),chunksize,offset)),Int.(offset))
-GridChunks(a::Tuple, chunksize; offset = (_->0).(a)) = GridChunks(Int.(a), Int.(chunksize), Int.(getgridsize(a,chunksize,offset)),Int.(offset))
-function getgridsize(a,chunksize,offset)
-  map(a,chunksize,offset) do s,cs,of
-    fld1(s+of,cs)
+function Base.getindex(r::RegularChunks,i::Int) 
+  @boundscheck checkbounds(r, i)
+  max((i-1)*r.cs+1-r.offset,1):min(i*r.cs-r.offset, r.s)
+end
+Base.size(r::RegularChunks,_) = div(r.s + r.offset - 1,r.cs) +1
+Base.size(r::RegularChunks) = (size(r,1),)
+function subsetchunks(r::RegularChunks, subs::AbstractUnitRange)
+  snew = length(subs)
+  newoffset = mod(first(subs)-1+r.offset,r.cs)
+  RegularChunks(r.cs, newoffset, snew)
+end
+function subsetchunks(r::RegularChunks, subs::AbstractRange)
+  #This is a method only to make "reverse" work and should error for all other cases
+  if step(subs) == -1 && first(subs)==r.s && last(subs)==1
+    lastlen = length(last(r))
+    newoffset = r.cs-lastlen
+    return RegularChunks(r.cs, newoffset, r.s)
   end
 end
-function Base.show(io::IO, g::GridChunks)
-  print(io,"Regular ",join(g.chunksize,"x")," chunks over a ", join(g.parentsize,"x"), " array.")
+approx_cs(r::RegularChunks) = r.cs
+max_cs(r::RegularChunks) = r.cs
+
+"""
+    IrregularChunks
+
+Defines chunks along a dimension where chunk sizes are not constant but arbitrary
+"""
+struct IrregularChunks <: ChunkType
+  offsets::Vector{Int}
 end
-Base.size(g::GridChunks) = g.chunkgridsize
-Base.size(g::GridChunks, dim) = g.chunkgridsize[dim]
-Base.IteratorSize(::Type{GridChunks{N}}) where N = Base.HasShape{N}()
-Base.eltype(::Type{GridChunks{N}}) where N = CartesianIndices{N,NTuple{N,UnitRange{Int64}}}
-Base.length(c::GridChunks) = prod(size(c))
-@inline function _iterate(g,r)
-    if r === nothing
-        return nothing
-    else
-        ichunk, state = r
-        outinds = map(ichunk.I, g.chunksize, g.parentsize,g.offset) do ic, cs, ps, of
-            max((ic-1)*cs+1-of,1):min(ic*cs-of, ps)
-        end |> CartesianIndices
-        outinds, state
-    end
+function Base.getindex(r::IrregularChunks,i::Int) 
+  @boundscheck checkbounds(r, i)
+  (r.offsets[i]+1):r.offsets[i+1]
 end
-function Base.iterate(g::GridChunks)
-    r = iterate(CartesianIndices(g.chunkgridsize))
-    _iterate(g,r)
+Base.size(r::IrregularChunks) = (length(r.offsets)-1,)
+function subsetchunks(r::IrregularChunks, subs::UnitRange)
+  c1 = searchsortedfirst(r.offsets, first(subs))-1
+  c2 = searchsortedfirst(r.offsets, last(subs))
+  offsnew = r.offsets[c1:c2]
+  firstoffset = first(subs)-r.offsets[c1]-1
+  offsnew[end] = last(subs)
+  offsnew[2:end] .= offsnew[2:end] .- firstoffset
+  offsnew .= offsnew .- first(offsnew)
+  IrregularChunks(offsnew)
 end
-function Base.iterate(g::GridChunks, state)
-    r = iterate(CartesianIndices(g.chunkgridsize), state)
-    _iterate(g,r)
+approx_cs(r::IrregularChunks) = round(Int,mean(diff(r.offsets)))
+max_cs(r::IrregularChunks) = maximum(diff(r.offsets))
+
+
+"""
+    IrregularChunks(;chunksizes)
+
+Returns an IrregularChunks object for the given list of chunk sizes
+"""
+function IrregularChunks(;chunksizes)
+  offs = pushfirst!(cumsum(chunksizes),0)
+  #push!(offs,last(offs)+1)
+  IrregularChunks(offs)
+end
+
+
+struct GridChunks{N} <: AbstractArray{UnitRange,N}
+  chunks::Tuple{Vararg{ChunkType,N}}
+end
+function Base.getindex(g::GridChunks{N},i::Vararg{Int, N}) where N 
+  @boundscheck checkbounds(g, i...)
+  getindex.(g.chunks,i)
+end
+Base.size(g::GridChunks) = length.(g.chunks)
+GridChunks(ct::ChunkType...) = GridChunks(ct)
+GridChunks(a, chunksize; offset = (_->0).(size(a))) = GridChunks(size(a), chunksize; offset)
+function GridChunks(a::Tuple, chunksize; offset = (_->0).(a))
+  gcs = map(a,chunksize, offset) do s, cs, of
+      RegularChunks(cs,of,s)
+  end
+  GridChunks(gcs)
 end
 
 #Define the approx default maximum chunk size (in MB)
@@ -60,8 +110,7 @@ const fallback_element_size = Ref(100)
 #be over-ridden by the package that implements the interface
 
 function eachchunk(a::AbstractArray)
-  cs = estimate_chunksize(a)
-  GridChunks(a,cs)
+  estimate_chunksize(a)
 end
 
 struct Chunked end
@@ -90,7 +139,7 @@ end
 estimate_chunksize(a::AbstractArray) = estimate_chunksize(size(a), element_size(a))
 function estimate_chunksize(s, si)
   ii = searchsortedfirst(cumprod(collect(s)),default_chunk_size[]*1e6/si)
-  ntuple(length(s)) do idim
+  cs = ntuple(length(s)) do idim
     if idim<ii
       return s[idim]
     elseif idim>ii
@@ -100,4 +149,5 @@ function estimate_chunksize(s, si)
       return floor(Int,default_chunk_size[]*1e6/si/sbefore)
     end
   end
+  GridChunks(s,cs)
 end

--- a/src/ops.jl
+++ b/src/ops.jl
@@ -48,23 +48,9 @@ function common_chunks(s,args...)
     totalsize = sum(sizeof ∘ eltype, args)
     return estimate_chunksize(s,totalsize)
   else
-
-    #allcs = map(ar->(eachchunk(ar).chunksize,eachchunk(ar).offset),chunkedars)
-    
-    # tt = ntuple(N) do n
-    #   csnow = filter(cs->length(cs[1])>=n && cs[1][n]>1,allcs)
-    #   isempty(csnow) && return (1, 0)
-    #   cs = (csnow[1][1][n],csnow[1][2][n])
-    #   all(s->(s[1][n],s[2][n]) == cs,csnow) || error("Chunks do not align in dimension $n")
-    #   return cs
-    # end
-    # return map(i->i[1],tt),map(i->i[2],tt)
-
     allcs = eachchunk.(chunkedars)
     tt = ntuple(N) do n
-      
       csnow = filter(cs->ndims(cs)>=n && first(first(cs.chunks[n]))<last(last(cs.chunks[n])),allcs)
-
       isempty(csnow) && return RegularChunks(1,0,s[n])
       cs = first(csnow).chunks[n]
       all(s->s.chunks[n] == cs,csnow) || error("Chunks do not align in dimension $n")

--- a/src/ops.jl
+++ b/src/ops.jl
@@ -23,8 +23,7 @@ end
 Base.broadcastable(bc::BroadcastDiskArray) = bc.bc
 haschunks(a::BroadcastDiskArray) = Chunked()
 function eachchunk(a::BroadcastDiskArray)
-  cs,off = common_chunks(size(a.bc),a.bc.args...)
-  GridChunks(a.bc,cs,offset=off)
+  common_chunks(size(a.bc),a.bc.args...)
 end
 function Base.copy(bc::Broadcasted{ChunkStyle{N}}) where N
   BroadcastDiskArray(flatten(bc))
@@ -32,13 +31,12 @@ end
 Base.copy(a::BroadcastDiskArray) = copyto!(zeros(eltype(a),size(a)),a.bc)
 function Base.copyto!(dest::AbstractArray, bc::Broadcasted{ChunkStyle{N}}) where N
   bcf = flatten(bc)
-  cs,off = common_chunks(size(bcf),dest,bcf.args...)
-  gcd = GridChunks(bcf,cs,offset=off)
+  gcd = common_chunks(size(bcf),dest,bcf.args...)
   foreach(gcd) do cnow
     #Possible optimization would be to use a LRU cache here, so that data has not
     #to be read twice in case of repeating indices
-    argssub = map(i->subsetarg(i,cnow.indices),bcf.args)
-    dest[cnow.indices...] .= bcf.f.(argssub...)
+    argssub = map(i->subsetarg(i,cnow),bcf.args)
+    dest[cnow...] .= bcf.f.(argssub...)
   end
   dest
 end
@@ -48,18 +46,31 @@ function common_chunks(s,args...)
   all(ar->isa(eachchunk(ar),GridChunks), chunkedars) || error("Currently only chunks of type GridChunks can be merged by broadcast")
   if isempty(chunkedars)
     totalsize = sum(sizeof ∘ eltype, args)
-    return (estimate_chunksize(s,totalsize),ntuple(zero,N))
+    return estimate_chunksize(s,totalsize)
   else
 
-    allcs = map(ar->(eachchunk(ar).chunksize,eachchunk(ar).offset),chunkedars)
+    #allcs = map(ar->(eachchunk(ar).chunksize,eachchunk(ar).offset),chunkedars)
+    
+    # tt = ntuple(N) do n
+    #   csnow = filter(cs->length(cs[1])>=n && cs[1][n]>1,allcs)
+    #   isempty(csnow) && return (1, 0)
+    #   cs = (csnow[1][1][n],csnow[1][2][n])
+    #   all(s->(s[1][n],s[2][n]) == cs,csnow) || error("Chunks do not align in dimension $n")
+    #   return cs
+    # end
+    # return map(i->i[1],tt),map(i->i[2],tt)
+
+    allcs = eachchunk.(chunkedars)
     tt = ntuple(N) do n
-      csnow = filter(cs->length(cs[1])>=n && cs[1][n]>1,allcs)
-      isempty(csnow) && return (1, 0)
-      cs = (csnow[1][1][n],csnow[1][2][n])
-      all(s->(s[1][n],s[2][n]) == cs,csnow) || error("Chunks do not align in dimension $n")
+      
+      csnow = filter(cs->ndims(cs)>=n && first(first(cs.chunks[n]))<last(last(cs.chunks[n])),allcs)
+
+      isempty(csnow) && return RegularChunks(1,0,s[n])
+      cs = first(csnow).chunks[n]
+      all(s->s.chunks[n] == cs,csnow) || error("Chunks do not align in dimension $n")
       return cs
     end
-    return map(i->i[1],tt),map(i->i[2],tt)
+    return GridChunks(tt...)
   end
 end
 subsetarg(x, a) = x

--- a/src/permute_reshape.jl
+++ b/src/permute_reshape.jl
@@ -16,12 +16,12 @@ function eachchunk(a::ReshapedDiskArray{<:Any,N}) where N
   outchunks = ntuple(N) do idim
     if in(idim,a.keepdim)
       inow+=1
-      pchunks.chunksize[inow],pchunks.offset[inow]
+      pchunks.chunks[inow]
     else
-      (1,0)
+      RegularChunks(1,0,size(a,idim))
     end
   end
-  GridChunks(a,first.(outchunks), offset=last.(outchunks))
+  GridChunks(outchunks...)
 end
 
 function DiskArrays.readblock!(a::ReshapedDiskArray,aout,i::OrdinalRange...)
@@ -76,7 +76,7 @@ _getiperm(::PermutedDimsArray{<:Any,<:Any,<:Any,iperm}) where iperm = iperm
 function eachchunk(a::PermutedDiskArray)
   cc = eachchunk(a.a.parent)
   perm = _getperm(a.a)
-  GridChunks(a,genperm(cc.chunksize,perm),offset=genperm(cc.offset,perm))
+  GridChunks(genperm(cc.chunks,perm)...)
 end
 function DiskArrays.readblock!(a::PermutedDiskArray,aout,i::OrdinalRange...)
   iperm = _getiperm(a)

--- a/src/subarrays.jl
+++ b/src/subarrays.jl
@@ -29,11 +29,8 @@ function eachchunk_view(::Chunked, vv)
   pinds = parentindices(vv)
   iomit = findints(pinds)
   chunksparent = eachchunk(parent(vv))
-  #TODO this currently only works if the parent chunks are GridChunks, should be generalized in the future
-  parentoffset, parentsize = chunksparent.offset, chunksparent.chunksize
-  offsets = ([mod1(first(pinds[i]),parentsize[i])+parentoffset[i]-1 for i in 1:length(pinds) if !in(i,iomit)]...,)
-  newcs = ([parentsize[i] for i in 1:length(pinds) if !in(i,iomit)]...,)
-  GridChunks(vv,newcs,offset = offsets)
+  newchunks = [subsetchunks(chunksparent.chunks[i], pinds[i]) for i in 1:length(pinds) if !in(i,iomit)]
+  GridChunks(newchunks...)
 end
 eachchunk_view(::Unchunked, a) = GridChunks(a,estimate_chunksize(a))
 haschunks(a::SubDiskArray) = haschunks(parent(a.v))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -238,8 +238,6 @@ end
   test_view(a)
 end
 
-# The remaing tests only work for Julia >= 1.3
-if VERSION >= v"1.3.0"
 import Statistics: mean
 @testset "Reductions" begin
   a = data -> _DiskArray(data,chunksize=(5,4,2))
@@ -351,4 +349,3 @@ end
   @test DiskArrays.eachchunk(c) == DiskArrays.GridChunks(c,(200,625))
 end
 
-end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -199,6 +199,9 @@ end
   @test gridc[2,2,2] == (4:8, 3:4,4:6)
   @test_throws BoundsError gridc[4,1,1]
   @test size(gridc) == (3,10,5)
+  @test DiskArrays.approx_chunksize(gridc) == (5,2,3)
+  @test DiskArrays.grid_offset(gridc) == (2,0,0)
+  @test DiskArrays.max_chunksize(gridc) == (5,2,4)
 end
 
 @testset "Index interpretation" begin


### PR DESCRIPTION
This PR implements a re-design of the GridChunks type which defines the chunk sizes for a DiskArray. The main purpose of this redesign is to provide more first-class support for arrays with non-constant chunk sizes. This happens quite frequently when concatenating NetCDFs along an axis that does not have constant length (for example concatenating annual NetCDF files along time axis where some have a leap year and some don't). An example use case is `ConcatDiskArray` from DiskArrayTools.jl. 

This PR makes it possible to use views, reshape, broadcast and permutations also on these irregular arrays. Since we change the way that `GridChunks` works, I would bump the minor version here although that name is not exported. This would also give us a bit more time for consolidation and testing and dependents can decide when they want to update their deps sections and check if tests pass. @rafaqz it would be nice if you can test this with a recent DimensionalData and Rasters version as well