### PR TITLE
Fix views of unchunked diskarrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiskArrays"
 uuid = "3c3547ce-8d99-4f5e-a174-61eb10b00ae3"
 authors = ["Fabian Gans <fgans@bgc-jena.mpg.de>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [compat]
 julia = "1.6"

--- a/src/subarrays.jl
+++ b/src/subarrays.jl
@@ -32,5 +32,5 @@ function eachchunk_view(::Chunked, vv)
   newchunks = [subsetchunks(chunksparent.chunks[i], pinds[i]) for i in 1:length(pinds) if !in(i,iomit)]
   GridChunks(newchunks...)
 end
-eachchunk_view(::Unchunked, a) = GridChunks(a,estimate_chunksize(a))
+eachchunk_view(::Unchunked, a) = estimate_chunksize(a)
 haschunks(a::SubDiskArray) = haschunks(parent(a.v))


### PR DESCRIPTION
So far, DiskArrays that returned "Unchunked" as their chunk status seem to not have had tests yet, which lead to #51 . This fixes #51 and adds at least one test that would have covered this use case. It might make sense to add some more tests here, maybe @rafaqz has a few ideas from DimensionalData?