### PR TITLE
apply bluestyle

### DIFF
--- a/src/DiskArrays.jl
+++ b/src/DiskArrays.jl
@@ -1,232 +1,8 @@
 module DiskArrays
+
 export AbstractDiskArray, interpret_indices_disk
 
-"""
-Abstract DiskArray type that can be inherited by Array-like data structures that
-have a significant random access overhead and whose access pattern follows
-n-dimensional (hyper)-rectangles.
-"""
-abstract type AbstractDiskArray{T,N} <: AbstractArray{T,N} end
-
-Base.ndims(::Type{<:AbstractDiskArray{T,N}}) where {T,N} = N
-
-"""
-    readblock!(A::AbstractDiskArray, A_ret, r::AbstractUnitRange...)
-
-The only function that should be implemented by a `AbstractDiskArray`. This function
-"""
-function readblock!() end
-
-"""
-    writeblock!(A::AbstractDiskArray, A_in, r::AbstractUnitRange...)
-
-Function that should be implemented by a `AbstractDiskArray` if write operations
-should be supported as well.
-"""
-function writeblock!() end
-
-function readblock!(A::AbstractDiskArray, A_ret, r::AbstractVector...)
-  #Implement fallback method if DiskArray does not support strided reading
-  #Currently this allocates an intermediate array. In the future, this
-  #function could test how sparse the reading is and maybe be smarter here
-  #by reading slices.
-  mi,ma = map(minimum,r), map(maximum,r)
-  A_temp = similar(A_ret,map((a,b)->b-a+1,mi,ma))
-  readblock!(A,A_temp,map(:,mi,ma)...)
-  A_ret .= view(A_temp,map(ir->ir.-(minimum(ir).-1),r)...)
-  nothing
-end
-
-function writeblock!(A::AbstractDiskArray, A_ret, r::AbstractVector...)
-  #Implement fallback method if DiskArray does not support strided reading
-  #Currently this allocates an intermediate array. In the future, this
-  #function could test how sparse the reading is and maybe be smarter here
-  #by reading slices.
-  mi,ma = map(minimum,r), map(maximum,r)
-  A_temp = similar(A_ret,map((a,b)->b-a+1,mi,ma))
-  A_temp[map(ir->ir.-(minimum(ir).-1),r)...] = A_ret
-  writeblock!(A,A_temp,map(:,mi,ma)...)
-  nothing
-end
-
-Base.ndims(::AbstractDiskArray{<:Any,N}) where N = N
-Base.eltype(::AbstractDiskArray{T}) where T = T
-
-
-
-function getindex_disk(a, i...)
-  inds, trans = interpret_indices_disk(a,i)
-  data = Array{eltype(a)}(undef, map(length,inds)...)
-  readblock!(a,data,inds...)
-  trans(data)
-end
-
-setindex_disk!(a::AbstractDiskArray{T},v::T,i...) where T<:AbstractArray = 
-  setindex_disk!(a,[v],i...)
-  
-function setindex_disk!(a::AbstractDiskArray,v::AbstractArray,i...)
-  inds, trans = interpret_indices_disk(a,i)
-  data = reshape(v,map(length,inds))
-  writeblock!(a,data,inds...)
-  v
-end
-
-"""
-Function that translates a list of user-supplied indices into plain ranges and
-integers for reading blocks of data. This function respects additional indexing
-rules like omitting additional trailing indices.
-
-The passed array handle A must implement methods for `Base.size` and `Base.ndims`
-The function returns two values:
-
-  1. a tuple whose length equals `ndims(A)` containing only unit
-  ranges and integers. This contains the minimal "bounding box" of data that
-  has to be read from disk.
-  2. A callable object which transforms the hyperrectangle read from disk to
-  the actual shape that represents the Base getindex behavior.
-"""
-function interpret_indices_disk(A, r::Tuple)
-  throw(ArgumentError("Indices of type $(typeof(r)) are not yet "))
-end
-
-#Read the entire array and reshape to 1D in the end
-function interpret_indices_disk(A, ::Tuple{Colon})
-  return map(Base.OneTo, size(A)), Reshaper(prod(size(A)))
-end
-
-interpret_indices_disk(A, r::Tuple{<:CartesianIndex}) =
-  interpret_indices_disk(A,r[1].I)
-
-interpret_indices_disk(A, r::Tuple{<:CartesianIndices}) =
-  interpret_indices_disk(A,r[1].indices)
-
-
-
-function interpret_indices_disk(A, r::NTuple{N, Union{Integer, AbstractVector, Colon}}) where N
-  if ndims(A)==N
-    inds = map(_convert_index,r,size(A))
-    resh = DimsDropper(findints(r))
-    return inds, resh
-  elseif ndims(A)<N
-    foreach((ndims(A)+1):N) do i
-      r[i]==1 || throw(BoundsError(A, r))
-    end
-    _, rshort = commonlength(size(A),r)
-    return interpret_indices_disk(A, rshort)
-  else
-    size(A,N+1)==1 || throw(BoundsError(A, r))
-    return interpret_indices_disk(A, (r...,1))
-  end
-end
-
-function interpret_indices_disk(A, r::Tuple{<:AbstractArray{<:Bool}})
-  ba = r[1]
-  if ndims(A)==ndims(ba)
-    inds = getbb(ba)
-    resh = a -> a[view(ba,inds...)]
-    return inds, resh
-  elseif ndims(ba)==1
-    interpret_indices_disk(A,(reshape(ba,size(A)),))
-  else
-    throw(BoundsError(A, r))
-  end
-end
-
-function interpret_indices_disk(A, r::NTuple{1, AbstractVector})
-  lininds = first(r)
-  cartinds = CartesianIndices(A)
-  mi, ma = extrema(view(cartinds, lininds))
-  inds = map((i1,i2) -> i1:i2, mi.I,ma.I)
-  resh = a -> map(lininds) do ii
-      a[cartinds[ii] - mi + oneunit(mi)]
-  end
-  inds, resh
-end
-
-
-struct Reshaper{I}
-  reshape_indices::I
-end
-(r::Reshaper)(a) = reshape(a,r.reshape_indices)
-struct DimsDropper{D}
-  d::D
-end
-(d::DimsDropper)(a) = length(d.d)==ndims(a) ? a[1] : dropdims(a,dims=d.d)
-struct TransformStack{S}
-  s::S
-end
-(s::TransformStack)(a) = ∘(s.s...)(a)
-
-function getbb(ar::AbstractArray{Bool})
-  maxval = CartesianIndex(size(ar))
-  minval = CartesianIndex{ndims(ar)}()
-  reduceop = (i1,i2)->begin i2===nothing ? i1 : (min(i1[1],i2),max(i1[2],i2)) end
-  mi,ma = mapfoldl(reduceop,
-    zip(CartesianIndices(ar),ar),
-    init = (maxval,minval)) do ii
-    ind,val = ii
-    val ? ind : nothing
-  end
-  inds = map((i1,i2) -> i1:i2, mi.I,ma.I)
-end
-
-#Some helper functions
-"For two given tuples return a truncated version of both so they have common length"
-commonlength(a, b) = _commonlength((first(a),), (first(b),),Base.tail(a), Base.tail(b))
-commonlength(::Tuple{}, b) = (),()
-commonlength(a, ::Tuple{}) = (),()
-_commonlength(a1, b1, a, b) = _commonlength((a1..., first(a)), (b1..., first(b)), Base.tail(a), Base.tail(b))
-_commonlength(a1, b1, ::Tuple{}, b) = (a1,b1)
-_commonlength(a1, b1, a, ::Tuple{}) = (a1, b1)
-
-"Find the indices of elements containing integers in a Tuple"
-findints(x) = _findints((),1,x...)
-_findints(c, i, x::Integer, rest...) = _findints((c..., i), i+1, rest...)
-_findints(c, i, x, rest...) = _findints(c, i+1, rest...)
-_findints(c, i)  = c
-#Normal indexing for a full subset of an array
-_convert_index(i::Integer, s::Integer) = i:i
-_convert_index(i::AbstractVector, s::Integer) = i
-_convert_index(::Colon, s::Integer) = Base.OneTo(Int(s))
-
-macro implement_getindex(t)
-quote
-function Base.getindex(a::$t,i...)
-  getindex_disk(a,i...)
-end
-end
-end
-
-macro implement_setindex(t)
-quote
-Base.setindex!(a::$t,v::AbstractArray,i...) =
-  setindex_disk!(a,v,i...)
-
-# Add an extra method if a single number is given
-Base.setindex!(a::$t{<:Any,N}, v, i...) where N =
-  Base.setindex!(a,fill(v,ntuple(i->1,N)...), i...)
-
-#Special care must be taken for logical indexing, we can not avoid reading the data
-#before writing
-function Base.setindex!(a::$t,v::AbstractArray,i::AbstractArray{<:Bool})
-  inds, trans = interpret_indices_disk(a,(i,))
-  data = Array{eltype(a)}(undef, map(length,inds)...)
-  readblock!(a,data,inds...)
-
-  data = reshape(v,map(length,inds))
-  writeblock!(a,data,inds...)
-  v
-end
-end
-end
-
-function Base.show(io::IO, ::MIME"text/plain", X::AbstractDiskArray)
-  println(io, "Disk Array with size ", join(size(X)," x "))
-end
-function Base.show(io::IO, X::AbstractDiskArray)
-  println(io, "Disk Array with size ", join(size(X)," x "))
-end
-
+include("diskarray.jl")
 include("array.jl")
 include("chunks.jl")
 include("ops.jl")
@@ -234,19 +10,21 @@ include("iterator.jl")
 include("subarrays.jl")
 include("permute_reshape.jl")
 
-#The all-in-one macro
+# The all-in-one macro
+
 macro implement_diskarray(t)
-quote
-  @implement_getindex $t
-  @implement_setindex $t
-  @implement_broadcast $t
-  @implement_iteration $t
-  @implement_mapreduce $t
-  @implement_reshape $t
-  @implement_array_methods $t
-  @implement_permutedims $t
-end
+    quote
+        @implement_getindex $t
+        @implement_setindex $t
+        @implement_broadcast $t
+        @implement_iteration $t
+        @implement_mapreduce $t
+        @implement_reshape $t
+        @implement_array_methods $t
+        @implement_permutedims $t
+    end
 end
 
 @implement_diskarray AbstractDiskArray
+
 end # module

--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -8,7 +8,7 @@ function eachchunk end
 abstract type ChunkType <: AbstractVector{UnitRange} end
 
 """
-    RegularChunks
+    RegularChunks <: ChunkType
 
 Defines chunking along a dimension where the chunks have constant size and a potential
 offset for the first chunk. The last chunk is truncated to fit the array size. 
@@ -18,90 +18,109 @@ struct RegularChunks <: ChunkType
     offset::Int
     s::Int
 end
-function Base.getindex(r::RegularChunks,i::Int) 
-  @boundscheck checkbounds(r, i)
-  max((i-1)*r.cs+1-r.offset,1):min(i*r.cs-r.offset, r.s)
+
+# Base methods
+
+function Base.getindex(r::RegularChunks, i::Int) 
+    @boundscheck checkbounds(r, i)
+    max((i - 1) * r.cs + 1 - r.offset, 1):min(i * r.cs - r.offset, r.s)
 end
-Base.size(r::RegularChunks,_) = div(r.s + r.offset - 1,r.cs) +1
-Base.size(r::RegularChunks) = (size(r,1),)
+Base.size(r::RegularChunks, _) = div(r.s + r.offset - 1, r.cs) + 1
+Base.size(r::RegularChunks) = (size(r, 1), )
+
+# DiskArrays interface
+
 function subsetchunks(r::RegularChunks, subs::AbstractUnitRange)
-  snew = length(subs)
-  newoffset = mod(first(subs)-1+r.offset,r.cs)
-  r = RegularChunks(r.cs, newoffset, snew)
-  #In case the new chunk is trivial and has length 1, we shorten the chunk size
-  if length(r) == 1
-    r = RegularChunks(snew, 0, snew)
-  end
-  r
+    snew = length(subs)
+    newoffset = mod(first(subs) - 1 + r.offset, r.cs)
+    r = RegularChunks(r.cs, newoffset, snew)
+    # In case the new chunk is trivial and has length 1, we shorten the chunk size
+    if length(r) == 1
+        r = RegularChunks(snew, 0, snew)
+    end
+    return r
 end
 function subsetchunks(r::RegularChunks, subs::AbstractRange)
-  #This is a method only to make "reverse" work and should error for all other cases
-  if step(subs) == -1 && first(subs)==r.s && last(subs)==1
-    lastlen = length(last(r))
-    newoffset = r.cs-lastlen
-    return RegularChunks(r.cs, newoffset, r.s)
-  end
+    # This is a method only to make "reverse" work and should error for all other cases
+    if step(subs) == -1 && first(subs)==r.s && last(subs)==1
+        lastlen = length(last(r))
+        newoffset = r.cs-lastlen
+        return RegularChunks(r.cs, newoffset, r.s)
+    end
 end
 approx_chunksize(r::RegularChunks) = r.cs
 grid_offset(r::RegularChunks) = r.offset
 max_chunksize(r::RegularChunks) = r.cs
 
+
 """
-    IrregularChunks
+    IrregularChunks <: ChunkType
 
 Defines chunks along a dimension where chunk sizes are not constant but arbitrary
 """
 struct IrregularChunks <: ChunkType
-  offsets::Vector{Int}
+    offsets::Vector{Int}
 end
-function Base.getindex(r::IrregularChunks,i::Int) 
-  @boundscheck checkbounds(r, i)
-  (r.offsets[i]+1):r.offsets[i+1]
+
+"""
+    IrregularChunks(; chunksizes)
+
+Returns an IrregularChunks object for the given list of chunk sizes
+"""
+function IrregularChunks(; chunksizes)
+    offs = pushfirst!(cumsum(chunksizes), 0)
+    # push!(offs, last(offs)+1)
+    return IrregularChunks(offs)
 end
-Base.size(r::IrregularChunks) = (length(r.offsets)-1,)
+
+# Base methods
+
+function Base.getindex(r::IrregularChunks, i::Int) 
+    @boundscheck checkbounds(r, i)
+    return (r.offsets[i] + 1):r.offsets[i + 1]
+end
+Base.size(r::IrregularChunks) = (length(r.offsets) - 1, )
+
+# DiskArrays interface
+
 function subsetchunks(r::IrregularChunks, subs::UnitRange)
-  c1 = searchsortedfirst(r.offsets, first(subs))-1
-  c2 = searchsortedfirst(r.offsets, last(subs))
-  offsnew = r.offsets[c1:c2]
-  firstoffset = first(subs)-r.offsets[c1]-1
-  offsnew[end] = last(subs)
-  offsnew[2:end] .= offsnew[2:end] .- firstoffset
-  offsnew .= offsnew .- first(offsnew)
-  IrregularChunks(offsnew)
+    c1 = searchsortedfirst(r.offsets, first(subs)) - 1
+    c2 = searchsortedfirst(r.offsets, last(subs))
+    offsnew = r.offsets[c1:c2]
+    firstoffset = first(subs)-r.offsets[c1] - 1
+    offsnew[end] = last(subs)
+    offsnew[2:end] .= offsnew[2:end] .- firstoffset
+    offsnew .= offsnew .- first(offsnew)
+    return IrregularChunks(offsnew)
 end
-approx_chunksize(r::IrregularChunks) = round(Int,sum(diff(r.offsets))/(length(r.offsets)-1))
+function approx_chunksize(r::IrregularChunks)
+    round(Int, sum(diff(r.offsets)) / (length(r.offsets) - 1))
+end
 grid_offset(r::IrregularChunks) = 0
 max_chunksize(r::IrregularChunks) = maximum(diff(r.offsets))
 
 
-"""
-    IrregularChunks(;chunksizes)
-
-Returns an IrregularChunks object for the given list of chunk sizes
-"""
-function IrregularChunks(;chunksizes)
-  offs = pushfirst!(cumsum(chunksizes),0)
-  #push!(offs,last(offs)+1)
-  IrregularChunks(offs)
-end
-
-
 struct GridChunks{N} <: AbstractArray{NTuple{N,UnitRange{Int64}},N}
-  chunks::Tuple{Vararg{ChunkType,N}}
+    chunks::Tuple{Vararg{ChunkType, N}}
 end
-function Base.getindex(g::GridChunks{N},i::Vararg{Int, N}) where N 
-  @boundscheck checkbounds(g, i...)
-  getindex.(g.chunks,i)
+GridChunks(ct::ChunkType...) = GridChunks(ct)
+GridChunks(a, chunksize; offset=(_ -> 0).(size(a))) = GridChunks(size(a), chunksize; offset)
+function GridChunks(a::Tuple, chunksize; offset=(_ -> 0).(a))
+    gcs = map(a, chunksize, offset) do s, cs, of
+        RegularChunks(cs, of, s)
+    end
+    return GridChunks(gcs)
+end
+
+# Base methods
+
+function Base.getindex(g::GridChunks{N}, i::Vararg{Int,N}) where N 
+    @boundscheck checkbounds(g, i...)
+    return getindex.(g.chunks, i)
 end
 Base.size(g::GridChunks) = length.(g.chunks)
-GridChunks(ct::ChunkType...) = GridChunks(ct)
-GridChunks(a, chunksize; offset = (_->0).(size(a))) = GridChunks(size(a), chunksize; offset)
-function GridChunks(a::Tuple, chunksize; offset = (_->0).(a))
-  gcs = map(a,chunksize, offset) do s, cs, of
-      RegularChunks(cs,of,s)
-  end
-  GridChunks(gcs)
-end
+
+# DiskArrays interface
 
 """
     approx_chunksize(g::GridChunks)
@@ -128,9 +147,7 @@ a chunk of data.
 """
 max_chunksize(g::GridChunks) = max_chunksize.(g.chunks)
 
-
-
-#Define the approx default maximum chunk size (in MB)
+# Define the approx default maximum chunk size (in MB)
 "The target chunk size for processing for unchunked arrays in MB, defaults to 100MB"
 const default_chunk_size = Ref(100)
 
@@ -140,15 +157,18 @@ size like strings. Defaults to 100MB
 """
 const fallback_element_size = Ref(100)
 
-#Here we implement a fallback chunking for a DiskArray although this should normally
-#be over-ridden by the package that implements the interface
+# Here we implement a fallback chunking for a DiskArray although this should normally
+# be over-ridden by the package that implements the interface
 
 function eachchunk(a::AbstractArray)
-  estimate_chunksize(a)
+    estimate_chunksize(a)
 end
+
+# Chunked trait
 
 struct Chunked end
 struct Unchunked end
+
 function haschunks end
 haschunks(x) = Unchunked()
 
@@ -160,28 +180,28 @@ the element type or to the value stored in `DiskArrays.fallback_element_size`. M
 custom containers. 
 """
 function element_size(a::AbstractArray) 
-  if isbitstype(eltype(a))
-    return sizeof(eltype(a))
-  elseif isbitstype(Base.nonmissingtype(eltype(a)))
-    return sizeof(Base.nonmissingtype(eltype(a)))
-  else
-    @warn "Can not determine size of element type. Using DiskArrays.fallback_element_size[] = $(fallback_element_size[]) bytes"
-    return fallback_element_size[]
-  end
+    if isbitstype(eltype(a))
+        return sizeof(eltype(a))
+    elseif isbitstype(Base.nonmissingtype(eltype(a)))
+        return sizeof(Base.nonmissingtype(eltype(a)))
+    else
+        @warn "Can not determine size of element type. Using DiskArrays.fallback_element_size[] = $(fallback_element_size[]) bytes"
+        return fallback_element_size[]
+    end
 end
 
 estimate_chunksize(a::AbstractArray) = estimate_chunksize(size(a), element_size(a))
 function estimate_chunksize(s, si)
-  ii = searchsortedfirst(cumprod(collect(s)),default_chunk_size[]*1e6/si)
-  cs = ntuple(length(s)) do idim
-    if idim<ii
-      return s[idim]
-    elseif idim>ii
-      return 1
-    else
-      sbefore = idim == 1 ? 1 : prod(s[1:idim-1])
-      return floor(Int,default_chunk_size[]*1e6/si/sbefore)
+    ii = searchsortedfirst(cumprod(collect(s)), default_chunk_size[] * 1e6 / si)
+    cs = ntuple(length(s)) do idim
+        if idim<ii
+            return s[idim]
+        elseif idim>ii
+            return 1
+        else
+            sbefore = idim == 1 ? 1 : prod(s[1:idim - 1])
+            return floor(Int, default_chunk_size[] * 1e6 / si / sbefore)
+        end
     end
-  end
-  GridChunks(s,cs)
+    return GridChunks(s, cs)
 end

--- a/src/diskarray.jl
+++ b/src/diskarray.jl
@@ -1,0 +1,226 @@
+"""
+    AbstractDiskArray <: AbstractArray
+
+Abstract DiskArray type that can be inherited by Array-like data structures that
+have a significant random access overhead and whose access pattern follows
+n-dimensional (hyper)-rectangles.
+"""
+abstract type AbstractDiskArray{T,N} <: AbstractArray{T,N} end
+
+# Base methods
+
+Base.ndims(::AbstractDiskArray{<:Any, N}) where N = N
+Base.eltype(::AbstractDiskArray{T}) where T = T
+function Base.show(io::IO, ::MIME"text/plain", X::AbstractDiskArray)
+    println(io, "Disk Array with size ", join(size(X), " x "))
+end
+function Base.show(io::IO, X::AbstractDiskArray)
+    println(io, "Disk Array with size ", join(size(X), " x "))
+end
+
+# DiskArrays interface
+
+"""
+    readblock!(A::AbstractDiskArray, A_ret, r::AbstractUnitRange...)
+
+The only function that should be implemented by a `AbstractDiskArray`. This function
+"""
+function readblock! end
+
+"""
+    writeblock!(A::AbstractDiskArray, A_in, r::AbstractUnitRange...)
+
+Function that should be implemented by a `AbstractDiskArray` if write operations
+should be supported as well.
+"""
+function writeblock! end
+
+function readblock!(A::AbstractDiskArray, A_ret, r::AbstractVector...)
+    # Implement fallback method if DiskArray does not support strided reading
+    # Currently this allocates an intermediate array. In the future, this
+    # function could test how sparse the reading is and maybe be smarter here
+    # by reading slices.
+    mi, ma = map(minimum, r), map(maximum, r)
+    A_temp = similar(A_ret, map((a, b)->b-a+1, mi, ma))
+    readblock!(A, A_temp, map(:, mi, ma)...)
+    A_ret .= view(A_temp, map(ir->ir.-(minimum(ir).-1), r)...)
+    return nothing
+end
+
+function writeblock!(A::AbstractDiskArray, A_ret, r::AbstractVector...)
+    # Implement fallback method if DiskArray does not support strided reading
+    # Currently this allocates an intermediate array. In the future, this
+    # function could test how sparse the reading is and maybe be smarter here
+    # by reading slices.
+    mi, ma = map(minimum, r), map(maximum, r)
+    A_temp = similar(A_ret, map((a, b)->b-a+1, mi, ma))
+    A_temp[map(ir->ir.-(minimum(ir).-1), r)...] = A_ret
+    writeblock!(A, A_temp, map(:, mi, ma)...)
+    return nothing
+end
+
+function getindex_disk(a, i...)
+    inds, trans = interpret_indices_disk(a, i)
+    data = Array{eltype(a)}(undef, map(length, inds)...)
+    readblock!(a, data, inds...)
+    return trans(data)
+end
+
+function setindex_disk!(a::AbstractDiskArray{T}, v::T, i...) where T<:AbstractArray
+    setindex_disk!(a, [v], i...)
+end
+function setindex_disk!(a::AbstractDiskArray, v::AbstractArray, i...)
+    inds, trans = interpret_indices_disk(a, i)
+    data = reshape(v, map(length, inds))
+    writeblock!(a, data, inds...)
+    return v
+end
+
+"""
+    interpret_indices_disk(A, r)
+
+Function that translates a list of user-supplied indices into plain ranges and
+integers for reading blocks of data. This function respects additional indexing
+rules like omitting additional trailing indices.
+
+The passed array handle A must implement methods for `Base.size` and `Base.ndims`
+The function returns two values:
+
+  1. a tuple whose length equals `ndims(A)` containing only unit
+  ranges and integers. This contains the minimal "bounding box" of data that
+  has to be read from disk.
+  2. A callable object which transforms the hyperrectangle read from disk to
+  the actual shape that represents the Base getindex behavior.
+"""
+function interpret_indices_disk(A, r::Tuple)
+    throw(ArgumentError("Indices of type $(typeof(r)) are not yet "))
+end
+# Read the entire array and reshape to 1D in the end
+function interpret_indices_disk(A, ::Tuple{Colon})
+    return map(Base.OneTo, size(A)), Reshaper(prod(size(A)))
+end
+interpret_indices_disk(A, r::Tuple{<:CartesianIndex}) =
+interpret_indices_disk(A, r[1].I)
+interpret_indices_disk(A, r::Tuple{<:CartesianIndices}) =
+interpret_indices_disk(A, r[1].indices)
+function interpret_indices_disk(A, r::NTuple{N,Union{Integer,AbstractVector,Colon}}) where N
+    if ndims(A) == N
+        inds = map(_convert_index, r, size(A))
+        resh = DimsDropper(findints(r))
+        return inds, resh
+    elseif ndims(A) < N
+        foreach((ndims(A) + 1):N) do i
+            r[i] == 1 || throw(BoundsError(A, r))
+        end
+        _, rshort = commonlength(size(A), r)
+        return interpret_indices_disk(A, rshort)
+    else
+        size(A, N + 1) == 1 || throw(BoundsError(A, r))
+        return interpret_indices_disk(A, (r..., 1))
+    end
+end
+function interpret_indices_disk(A, r::Tuple{<:AbstractArray{<:Bool}})
+    ba = r[1]
+    if ndims(A) == ndims(ba)
+        inds = getbb(ba)
+        resh = a -> a[view(ba, inds...)]
+        return inds, resh
+    elseif ndims(ba)==1
+        return interpret_indices_disk(A, (reshape(ba, size(A)), ))
+    else
+        throw(BoundsError(A, r))
+    end
+end
+function interpret_indices_disk(A, r::NTuple{1,AbstractVector})
+    lininds = first(r)
+    cartinds = CartesianIndices(A)
+    mi, ma = extrema(view(cartinds, lininds))
+    inds = map((i1, i2) -> i1:i2, mi.I, ma.I)
+    resh = a -> map(lininds) do ii
+        a[cartinds[ii] - mi + oneunit(mi)]
+    end
+    return inds, resh
+end
+
+# Reshaping functors
+
+struct Reshaper{I}
+    reshape_indices::I
+end
+(r::Reshaper)(a) = reshape(a, r.reshape_indices)
+
+struct DimsDropper{D}
+    d::D
+end
+(d::DimsDropper)(a) = length(d.d)==ndims(a) ? a[1] : dropdims(a, dims=d.d)
+
+struct TransformStack{S}
+    s::S
+end
+(s::TransformStack)(a) = ∘(s.s...)(a)
+
+function getbb(ar::AbstractArray{Bool})
+    maxval = CartesianIndex(size(ar))
+    minval = CartesianIndex{ndims(ar)}()
+    function reduceop(i1, i2)
+        i2 === nothing ? i1 : (min(i1[1], i2), max(i1[2], i2))
+    end
+    mi, ma = mapfoldl(reduceop, zip(CartesianIndices(ar), ar), init=(maxval, minval)) do ii
+        ind, val = ii
+        val ? ind : nothing
+    end
+    return map((i1, i2) -> i1:i2, mi.I, ma.I)
+end
+
+# Helper functions
+
+"For two given tuples return a truncated version of both so they have common length"
+commonlength(a, b) = _commonlength((first(a), ), (first(b), ), Base.tail(a), Base.tail(b))
+commonlength(::Tuple{}, b) = (), ()
+commonlength(a, ::Tuple{}) = (), ()
+
+_commonlength(a1, b1, a, b) = _commonlength((a1..., first(a)), (b1..., first(b)), Base.tail(a), Base.tail(b))
+_commonlength(a1, b1, ::Tuple{}, b) = (a1, b1)
+_commonlength(a1, b1, a, ::Tuple{}) = (a1, b1)
+
+"Find the indices of elements containing integers in a Tuple"
+findints(x) = _findints((), 1, x...)
+
+_findints(c, i, x::Integer, rest...) = _findints((c..., i), i + 1, rest...)
+_findints(c, i, x, rest...) = _findints(c, i + 1, rest...)
+_findints(c, i)  = c
+# Normal indexing for a full subset of an array
+_convert_index(i::Integer, s::Integer) = i:i
+_convert_index(i::AbstractVector, s::Integer) = i
+_convert_index(::Colon, s::Integer) = Base.OneTo(Int(s))
+
+# Implementation macros
+
+macro implement_getindex(t)
+    quote
+        function Base.getindex(a::$t, i...)
+            getindex_disk(a, i...)
+        end
+    end
+end
+
+macro implement_setindex(t)
+    quote
+        Base.setindex!(a::$t, v::AbstractArray, i...) = setindex_disk!(a, v, i...)
+        # Add an extra method if a single number is given
+        Base.setindex!(a::$t{<:Any,N}, v, i...) where N =
+            setindex!(a, fill(v, ntuple(i->1, N)...), i...)
+        # Special care must be taken for logical indexing, we can not avoid reading
+        # the data before writing
+        function Base.setindex!(a::$t, v::AbstractArray, i::AbstractArray{<:Bool})
+            inds, trans = interpret_indices_disk(a, (i, ))
+            data = Array{eltype(a)}(undef, map(length, inds)...)
+            readblock!(a, data, inds...)
+
+            data = reshape(v, map(length, inds))
+            writeblock!(a, data, inds...)
+            return v
+        end
+    end
+end
+

--- a/src/ops.jl
+++ b/src/ops.jl
@@ -1,146 +1,163 @@
 import Base.Broadcast: Broadcasted, AbstractArrayStyle, DefaultArrayStyle, flatten
-toRanges(r::Tuple) = r
-toRanges(r::CartesianIndices) = r.indices
+
+# DiskArrays broadcast style
 
 struct ChunkStyle{N} <: Base.Broadcast.AbstractArrayStyle{N} end
 
-Base.BroadcastStyle(::ChunkStyle{N}, ::ChunkStyle{M}) where {N,M}= ChunkStyle{max(N,M)}()
-Base.BroadcastStyle(::ChunkStyle{N}, ::DefaultArrayStyle{M}) where {N,M}= ChunkStyle{max(N,M)}()
-Base.BroadcastStyle(::DefaultArrayStyle{M},::ChunkStyle{N}) where {N,M}= ChunkStyle{max(N,M)}()
+Base.BroadcastStyle(::ChunkStyle{N}, ::ChunkStyle{M}) where {N, M}= ChunkStyle{max(N, M)}()
+Base.BroadcastStyle(::ChunkStyle{N}, ::DefaultArrayStyle{M}) where {N, M}= ChunkStyle{max(N, M)}()
+Base.BroadcastStyle(::DefaultArrayStyle{M}, ::ChunkStyle{N}) where {N, M}= ChunkStyle{max(N, M)}()
+
 
 struct BroadcastDiskArray{T,N,BC<:Broadcasted{<:ChunkStyle{N}}} <: AbstractDiskArray{T,N}
-  bc::BC
+    bc::BC
 end
 function BroadcastDiskArray(bcf::B) where {B<:Broadcasted{<:ChunkStyle{N}}} where N
-  ElType = Base.Broadcast.combine_eltypes(bcf.f, bcf.args)
-  BroadcastDiskArray{ElType,N,B}(bcf)
+    ElType = Base.Broadcast.combine_eltypes(bcf.f, bcf.args)
+    BroadcastDiskArray{ElType, N, B}(bcf)
 end
+
+# Base methods
+
 Base.size(bc::BroadcastDiskArray) = size(bc.bc)
-function DiskArrays.readblock!(a::BroadcastDiskArray,aout,i::OrdinalRange...)
-  argssub = map(arg->subsetarg(arg,i),a.bc.args)
-  aout .= a.bc.f.(argssub...)
+function DiskArrays.readblock!(a::BroadcastDiskArray, aout, i::OrdinalRange...)
+    argssub = map(arg->subsetarg(arg, i), a.bc.args)
+    aout .= a.bc.f.(argssub...)
 end
 Base.broadcastable(bc::BroadcastDiskArray) = bc.bc
+function Base.copy(bc::Broadcasted{ChunkStyle{N}}) where N
+    BroadcastDiskArray(flatten(bc))
+end
+Base.copy(a::BroadcastDiskArray) = copyto!(zeros(eltype(a), size(a)), a.bc)
+function Base.copyto!(dest::AbstractArray, bc::Broadcasted{ChunkStyle{N}}) where N
+    bcf = flatten(bc)
+    gcd = common_chunks(size(bcf), dest, bcf.args...)
+    foreach(gcd) do cnow
+        # Possible optimization would be to use a LRU cache here, so that data has not
+        # to be read twice in case of repeating indices
+        argssub = map(i->subsetarg(i, cnow), bcf.args)
+        dest[cnow...] .= bcf.f.(argssub...)
+    end
+    dest
+end
+
+# DiskArrays interface
+
 haschunks(a::BroadcastDiskArray) = Chunked()
 function eachchunk(a::BroadcastDiskArray)
-  common_chunks(size(a.bc),a.bc.args...)
+    common_chunks(size(a.bc), a.bc.args...)
 end
-function Base.copy(bc::Broadcasted{ChunkStyle{N}}) where N
-  BroadcastDiskArray(flatten(bc))
-end
-Base.copy(a::BroadcastDiskArray) = copyto!(zeros(eltype(a),size(a)),a.bc)
-function Base.copyto!(dest::AbstractArray, bc::Broadcasted{ChunkStyle{N}}) where N
-  bcf = flatten(bc)
-  gcd = common_chunks(size(bcf),dest,bcf.args...)
-  foreach(gcd) do cnow
-    #Possible optimization would be to use a LRU cache here, so that data has not
-    #to be read twice in case of repeating indices
-    argssub = map(i->subsetarg(i,cnow),bcf.args)
-    dest[cnow...] .= bcf.f.(argssub...)
-  end
-  dest
-end
-function common_chunks(s,args...)
-  N = length(s)
-  chunkedars = filter(i->haschunks(i)===Chunked(),collect(args))
-  all(ar->isa(eachchunk(ar),GridChunks), chunkedars) || error("Currently only chunks of type GridChunks can be merged by broadcast")
-  if isempty(chunkedars)
-    totalsize = sum(sizeof ∘ eltype, args)
-    return estimate_chunksize(s,totalsize)
-  else
-    allcs = eachchunk.(chunkedars)
-    tt = ntuple(N) do n
-      csnow = filter(cs->ndims(cs)>=n && first(first(cs.chunks[n]))<last(last(cs.chunks[n])),allcs)
-      isempty(csnow) && return RegularChunks(1,0,s[n])
-      cs = first(csnow).chunks[n]
-      all(s->s.chunks[n] == cs,csnow) || error("Chunks do not align in dimension $n")
-      return cs
+function common_chunks(s, args...)
+    N = length(s)
+    chunkedars = filter(i->haschunks(i)===Chunked(), collect(args))
+    all(ar->isa(eachchunk(ar), GridChunks), chunkedars) || error("Currently only chunks of type GridChunks can be merged by broadcast")
+    if isempty(chunkedars)
+        totalsize = sum(sizeof ∘ eltype, args)
+        return estimate_chunksize(s, totalsize)
+    else
+        allcs = eachchunk.(chunkedars)
+        tt = ntuple(N) do n
+            csnow = filter(allcs) do cs
+                ndims(cs) >= n && first(first(cs.chunks[n])) < last(last(cs.chunks[n]))
+            end
+            isempty(csnow) && return RegularChunks(1, 0, s[n])
+            cs = first(csnow).chunks[n]
+            all(s->s.chunks[n] == cs, csnow) || error("Chunks do not align in dimension $n")
+            return cs
+        end
+        return GridChunks(tt...)
     end
-    return GridChunks(tt...)
-  end
 end
+
+# Utility methods
+
+to_ranges(r::Tuple) = r
+to_ranges(r::CartesianIndices) = r.indices
+
 subsetarg(x, a) = x
-function subsetarg(x::AbstractArray,a)
-  ashort = maybeonerange(size(x),a)
-  view(x,ashort...) #Maybe making a copy here would be faster, need to check...
+function subsetarg(x::AbstractArray, a)
+    ashort = maybeonerange(size(x), a)
+    view(x, ashort...) # Maybe making a copy here would be faster, need to check...
 end
-repsingle(s,r) = s==1 ? (1:1) : r
-function maybeonerange(out,sizes,ranges)
-  s1,sr = splittuple(sizes...)
-  r1,rr = splittuple(ranges...)
-  maybeonerange((out...,repsingle(s1,r1)),sr,rr)
+repsingle(s, r) = s==1 ? (1:1) : r
+function maybeonerange(out, sizes, ranges)
+    s1, sr = splittuple(sizes...)
+    r1, rr = splittuple(ranges...)
+    maybeonerange((out..., repsingle(s1, r1)), sr, rr)
 end
-maybeonerange(out,::Tuple{},ranges) = out
-maybeonerange(sizes,ranges) = maybeonerange((),sizes,ranges)
-splittuple(x1,xr...) = x1,xr
+maybeonerange(out, ::Tuple{}, ranges) = out
+maybeonerange(sizes, ranges) = maybeonerange((), sizes, ranges)
+splittuple(x1, xr...) = x1, xr
+
+# Implementation macros
 
 macro implement_mapreduce(t)
-  quote
-    function Base._mapreduce(f,op,v::$t)
-      mapreduce(op,eachchunk(v)) do cI
-        a = v[toRanges(cI)...]
-        mapreduce(f,op,a)
-      end
-    end
-    function Base.mapreducedim!(f, op, R::AbstractArray, A::$t)
-      sR = size(R)
-      foreach(eachchunk(A)) do cI
-        a = A[toRanges(cI)...]
-        ainds = map((cinds, arsize)->arsize==1 ? Base.OneTo(1) : cinds, toRanges(cI),size(R))
-        #Maybe the view into R here is problematic and a copy would be faster
-        Base.mapreducedim!(f,op,view(R,ainds...),a)
-      end
-      R
-    end
+    quote
+        function Base._mapreduce(f, op, v::$t)
+            mapreduce(op, eachchunk(v)) do cI
+                a = v[to_ranges(cI)...]
+                mapreduce(f, op, a)
+            end
+        end
+        function Base.mapreducedim!(f, op, R::AbstractArray, A::$t)
+            sR = size(R)
+            foreach(eachchunk(A)) do cI
+                a = A[to_ranges(cI)...]
+                ainds = map((cinds, arsize)->arsize==1 ? Base.OneTo(1) : cinds, to_ranges(cI), size(R))
+                # Maybe the view into R here is problematic and a copy would be faster
+                Base.mapreducedim!(f, op, view(R, ainds...), a)
+            end
+            R
+        end
 
-    function Base.mapfoldl_impl(f, op, nt::NamedTuple{()}, itr::$t)
-      cc = eachchunk(itr)
-      isempty(cc) && return Base.mapreduce_empty_iter(f, op, itr, IteratorEltype(itr))
-      Base.mapfoldl_impl(f,op,nt,itr,cc)
+        function Base.mapfoldl_impl(f, op, nt::NamedTuple{()}, itr::$t)
+            cc = eachchunk(itr)
+            isempty(cc) && return Base.mapreduce_empty_iter(f, op, itr, IteratorEltype(itr))
+            Base.mapfoldl_impl(f, op, nt, itr, cc)
+        end
+        function Base.mapfoldl_impl(f, op, nt::NamedTuple{()}, itr::$t, cc)
+            y = first(cc)
+            a = itr[to_ranges(y)...]
+            init = mapfoldl(f, op, a)
+            Base.mapfoldl_impl(f, op, (init=init, ), itr, Iterators.drop(cc, 1))
+        end
+        function Base.mapfoldl_impl(f, op, nt::NamedTuple{(:init, )}, itr::$t, cc)
+            init = nt.init
+            for y in cc
+                a = itr[to_ranges(y)...]
+                init = mapfoldl(f, op, a, init=init)
+            end
+            init
+        end
     end
-    function Base.mapfoldl_impl(f, op, nt::NamedTuple{()}, itr::$t, cc)
-      y = first(cc)
-      a = itr[toRanges(y)...]
-      init = mapfoldl(f,op,a)
-      Base.mapfoldl_impl(f,op,(init=init,),itr,Iterators.drop(cc,1))
-    end
-    function Base.mapfoldl_impl(f, op, nt::NamedTuple{(:init,)}, itr::$t, cc)
-      init = nt.init
-      for y in cc
-        a = itr[toRanges(y)...]
-        init = mapfoldl(f,op,a,init=init)
-      end
-      init
-    end
-  end
 end
 
 macro implement_broadcast(t)
-  quote
-    #Broadcasting with a DiskArray on LHS
-    function Base.copyto!(dest::$t, bc::Broadcasted{Nothing})
-      foreach(eachchunk(dest)) do c
-        ar = [bc[i] for i in CartesianIndices(toRanges(c))]
-        dest[toRanges(c)...] = ar
-      end
-      dest
-    end
-    Base.BroadcastStyle(T::Type{<:$t}) = ChunkStyle{ndims(T)}()
-    function DiskArrays.subsetarg(x::$t,a)
-      ashort = maybeonerange(size(x),a)
-      x[ashort...]
-    end
+    quote
+        # Broadcasting with a DiskArray on LHS
+        function Base.copyto!(dest::$t, bc::Broadcasted{Nothing})
+            foreach(eachchunk(dest)) do c
+                ar = [bc[i] for i in CartesianIndices(to_ranges(c))]
+                dest[to_ranges(c)...] = ar
+            end
+            return dest
+        end
+        Base.BroadcastStyle(T::Type{<:$t}) = ChunkStyle{ndims(T)}()
+        function DiskArrays.subsetarg(x::$t, a)
+            ashort = maybeonerange(size(x), a)
+            return x[ashort...]
+        end
 
-    #This is a heavily allocating implementation, but working for all cases.
-    #As performance optimization one might:
-    #Allocate the array only once if all chunks have the same size
-    #Use FillArrays, if the DiskArray accepts these
-    function Base.fill!(dest::$t, value)
-      foreach(eachchunk(dest)) do c
-        ar = fill(value,length.(toRanges(c)))
-        dest[toRanges(c)...] = ar
-      end
-      dest
+        # This is a heavily allocating implementation, but working for all cases.
+        # As performance optimization one might:
+        # Allocate the array only once if all chunks have the same size
+        # Use FillArrays, if the DiskArray accepts these
+        function Base.fill!(dest::$t, value)
+            foreach(eachchunk(dest)) do c
+                ar = fill(value, length.(to_ranges(c)))
+                dest[to_ranges(c)...] = ar
+            end
+            return dest
+        end
     end
-  end
 end

--- a/src/permute_reshape.jl
+++ b/src/permute_reshape.jl
@@ -1,41 +1,46 @@
 import Base: _throw_dmrs
 import DiskArrays: splittuple
-#Reshaping is really not trivial, because the access pattern would completely change for reshaped arrays,
-#rectangles would not remain rectangles in the parent array. However, we can support the case where only
-#singleton dimensions are added, later we could allow more special cases like joining two dimensions to one
+import Base.PermutedDimsArrays: genperm
+
+# Reshaping is really not trivial, because the access pattern would completely change for reshaped arrays,
+# rectangles would not remain rectangles in the parent array. However, we can support the case where only
+# singleton dimensions are added, later we could allow more special cases like joining two dimensions to one
+
 struct ReshapedDiskArray{T,N,P<:AbstractArray{T},M} <: AbstractDiskArray{T,N}
     parent::P
     keepdim::NTuple{M,Int}
     newsize::NTuple{N,Int}
 end
-Base.size(r::ReshapedDiskArray) = r.newsize
-haschunks(a::ReshapedDiskArray) = haschunks(a.parent)
-function eachchunk(a::ReshapedDiskArray{<:Any,N}) where N
-  pchunks = eachchunk(a.parent)
-  inow::Int=0
-  outchunks = ntuple(N) do idim
-    if in(idim,a.keepdim)
-      inow+=1
-      pchunks.chunks[inow]
-    else
-      RegularChunks(1,0,size(a,idim))
-    end
-  end
-  GridChunks(outchunks...)
-end
 
-function DiskArrays.readblock!(a::ReshapedDiskArray,aout,i::OrdinalRange...)
-  inew = tuple_tuple_getindex(i,a.keepdim)
-  DiskArrays.readblock!(a.parent,reshape(aout,map(length,inew)),inew...)
-  nothing
+# Base methods
+
+Base.size(r::ReshapedDiskArray) = r.newsize
+
+# DiskArrays interface
+
+haschunks(a::ReshapedDiskArray) = haschunks(a.parent)
+function eachchunk(a::ReshapedDiskArray{<:Any, N}) where N
+    pchunks = eachchunk(a.parent)
+    inow::Int=0
+    outchunks = ntuple(N) do idim
+        if in(idim, a.keepdim)
+            inow+=1
+            pchunks.chunks[inow]
+        else
+            RegularChunks(1, 0, size(a, idim))
+        end
+    end
+    GridChunks(outchunks...)
 end
-tuple_tuple_getindex(t,i) = _ttgi((),t,i...)
-_ttgi(o,t,i1,irest...) = _ttgi((o...,t[i1]),t,irest...)
-_ttgi(o,t,i1) = (o...,t[i1])
-function DiskArrays.writeblock!(a::ReshapedDiskArray,v,i::OrdinalRange...)
-  inew = tuple_tuple_getindex(i,a.keepdim)
-  DiskArrays.writeblock!(a.parent,reshape(v,map(length,inew)),inew...)
-  nothing
+function DiskArrays.readblock!(a::ReshapedDiskArray, aout, i::OrdinalRange...)
+    inew = tuple_tuple_getindex(i, a.keepdim)
+    DiskArrays.readblock!(a.parent, reshape(aout, map(length, inew)), inew...)
+    nothing
+end
+function DiskArrays.writeblock!(a::ReshapedDiskArray, v, i::OrdinalRange...)
+    inew = tuple_tuple_getindex(i, a.keepdim)
+    DiskArrays.writeblock!(a.parent, reshape(v, map(length, inew)), inew...)
+    nothing
 end
 function reshape_disk(parent, dims)
     n = length(parent)
@@ -55,52 +60,62 @@ function reshape_disk(parent, dims)
             end
         end
     end
-    ReshapedDiskArray{eltype(parent),length(dims),typeof(parent),ndims(parent)}(parent,keepdim,dims)
+    ReshapedDiskArray{eltype(parent), length(dims), typeof(parent), ndims(parent)}(parent, keepdim, dims)
 end
 
-import Base: _throw_dmrs
-import Base.PermutedDimsArrays: genperm
+tuple_tuple_getindex(t, i) = _ttgi((), t, i...)
+_ttgi(o, t, i1, irest...) = _ttgi((o..., t[i1]), t, irest...)
+_ttgi(o, t, i1) = (o..., t[i1])
+
+
 struct PermutedDiskArray{T,N,P<:PermutedDimsArray{T,N}} <: AbstractDiskArray{T,N}
     a::P
 end
-function permutedims_disk(a,perm)
-  pd = PermutedDimsArray(a,perm)
-  PermutedDiskArray{eltype(a),ndims(a),typeof(pd)}(pd)
-end
+
+# Base methods
+
 Base.size(r::PermutedDiskArray) = size(r.a)
+
+# DiskArrays interface
+
+function permutedims_disk(a, perm)
+    pd = PermutedDimsArray(a, perm)
+    PermutedDiskArray{eltype(a), ndims(a), typeof(pd)}(pd)
+end
 haschunks(a::PermutedDiskArray) = haschunks(a.a.parent)
-_getperm(a::PermutedDiskArray) = _getperm(a.a)
-_getperm(::PermutedDimsArray{<:Any,<:Any,perm}) where perm = perm
-_getiperm(a::PermutedDiskArray) = _getiperm(a.a)
-_getiperm(::PermutedDimsArray{<:Any,<:Any,<:Any,iperm}) where iperm = iperm
 function eachchunk(a::PermutedDiskArray)
-  cc = eachchunk(a.a.parent)
-  perm = _getperm(a.a)
-  GridChunks(genperm(cc.chunks,perm)...)
+    cc = eachchunk(a.a.parent)
+    perm = _getperm(a.a)
+    GridChunks(genperm(cc.chunks, perm)...)
 end
-function DiskArrays.readblock!(a::PermutedDiskArray,aout,i::OrdinalRange...)
-  iperm = _getiperm(a)
-  inew = genperm(i, iperm)
-  DiskArrays.readblock!(a.a.parent,PermutedDimsArray(aout,iperm),inew...)
-  nothing
+function DiskArrays.readblock!(a::PermutedDiskArray, aout, i::OrdinalRange...)
+    iperm = _getiperm(a)
+    inew = genperm(i, iperm)
+    DiskArrays.readblock!(a.a.parent, PermutedDimsArray(aout, iperm), inew...)
+    nothing
 end
-function DiskArrays.writeblock!(a::PermutedDiskArray,v,i::OrdinalRange...)
-  iperm = _getiperm(a)
-  inew = genperm(i, iperm)
-  DiskArrays.writeblock!(a.a.parent,PermutedDimsArray(v,iperm),inew...)
-  nothing
+function DiskArrays.writeblock!(a::PermutedDiskArray, v, i::OrdinalRange...)
+    iperm = _getiperm(a)
+    inew = genperm(i, iperm)
+    DiskArrays.writeblock!(a.a.parent, PermutedDimsArray(v, iperm), inew...)
+    nothing
 end
 
+_getperm(a::PermutedDiskArray) = _getperm(a.a)
+_getperm(::PermutedDimsArray{<:Any, <:Any, perm}) where perm = perm
+_getiperm(a::PermutedDiskArray) = _getiperm(a.a)
+_getiperm(::PermutedDimsArray{<:Any, <:Any, <:Any, iperm}) where iperm = iperm
+
+# Implementaion macros
+
 macro implement_reshape(t)
-  quote
-    Base._reshape(parent::$t, dims::NTuple{N,Int}) where N =
-      reshape_disk(parent, dims)
-  end
+    quote
+        Base._reshape(parent::$t, dims::NTuple{N,Int}) where N = reshape_disk(parent, dims)
+    end
 end
 
 macro implement_permutedims(t)
-  quote
-    Base.permutedims(parent::$t, perm) =
-      permutedims_disk(parent, perm)
-  end
+    quote
+        Base.permutedims(parent::$t, perm) = permutedims_disk(parent, perm)
+    end
 end

--- a/src/subarrays.jl
+++ b/src/subarrays.jl
@@ -1,36 +1,41 @@
-struct SubDiskArray{T,N} <: AbstractDiskArray{T,N}
-  v::SubArray{T,N}
+struct SubDiskArray{T, N} <: AbstractDiskArray{T, N}
+    v::SubArray{T, N}
 end
-replace_colon(s,::Colon) = Base.OneTo(s)
-replace_colon(s,r) = r
-function Base.view(a::AbstractDiskArray,i...)
-  i2 = replace_colon.(size(a),i)
-  SubDiskArray(SubArray(a,i2))
+
+# Base methods
+function Base.view(a::AbstractDiskArray, i...)
+    i2 = _replace_colon.(size(a), i)
+    SubDiskArray(SubArray(a, i2))
 end
-Base.view(a::AbstractDiskArray, i::CartesianIndices) = view(a,i.indices...)
-function Base.view(a::SubDiskArray,i...)
-  SubDiskArray(view(a.v,i...))
+Base.view(a::AbstractDiskArray, i::CartesianIndices) = view(a, i.indices...)
+function Base.view(a::SubDiskArray, i...)
+    SubDiskArray(view(a.v, i...))
 end
-Base.view(a::SubDiskArray, i::CartesianIndices) = view(a,i.indices...)
-function readblock!(a::SubDiskArray,aout,i::OrdinalRange...)
-  pinds = parentindices(view(a.v,i...))
-  inds,resh = interpret_indices_disk(parent(a.v),pinds)
-  readblock!(parent(a.v),reshape(aout,map(length,inds)...),inds...)
-end
-function writeblock!(a::SubDiskArray,v,i::OrdinalRange...)
-  pinds = parentindices(view(a.v,i...))
-  inds,resh = interpret_indices_disk(parent(a.v),pinds)
-  writeblock!(parent(a.v),reshape(v,map(length,inds)...),inds...)
-end
+Base.view(a::SubDiskArray, i::CartesianIndices) = view(a, i.indices...)
 Base.size(a::SubDiskArray) = size(a.v)
-eachchunk(a::SubDiskArray) = eachchunk_view(haschunks(a.v.parent),a.v)
 Base.parent(a::SubDiskArray) = a.v.parent
+
+_replace_colon(s, ::Colon) = Base.OneTo(s)
+_replace_colon(s, r) = r
+
+# Diskarrays.jl interface
+function readblock!(a::SubDiskArray, aout, i::OrdinalRange...)
+    pinds = parentindices(view(a.v, i...))
+    inds, resh = interpret_indices_disk(parent(a.v), pinds)
+    readblock!(parent(a.v), reshape(aout, map(length, inds)...), inds...)
+end
+function writeblock!(a::SubDiskArray, v, i::OrdinalRange...)
+    pinds = parentindices(view(a.v, i...))
+    inds, resh = interpret_indices_disk(parent(a.v), pinds)
+    writeblock!(parent(a.v), reshape(v, map(length, inds)...), inds...)
+end
+eachchunk(a::SubDiskArray) = eachchunk_view(haschunks(a.v.parent), a.v)
 function eachchunk_view(::Chunked, vv)
-  pinds = parentindices(vv)
-  iomit = findints(pinds)
-  chunksparent = eachchunk(parent(vv))
-  newchunks = [subsetchunks(chunksparent.chunks[i], pinds[i]) for i in 1:length(pinds) if !in(i,iomit)]
-  GridChunks(newchunks...)
+    pinds = parentindices(vv)
+    iomit = findints(pinds)
+    chunksparent = eachchunk(parent(vv))
+    newchunks = [subsetchunks(chunksparent.chunks[i], pinds[i]) for i in 1:length(pinds) if !in(i, iomit)]
+    GridChunks(newchunks...)
 end
 eachchunk_view(::Unchunked, a) = estimate_chunksize(a)
 haschunks(a::SubDiskArray) = haschunks(parent(a.v))


### PR DESCRIPTION
This package is by necessity somewhat complicated and difficult to understand, but also an important dependency it would be good if more people could contribute to.

To ease the pain of learning it a little a little this PR applies a consistent style (https://github.com/invenia/BlueStyle) that is a bit more familiar to most julia developers.

Essentially this means:
- choose four space indent, currently we have 2 and 4
- spaces after commas and hashes
- spaces around infix operators other than colon
- explicit `return` in multi line functions
- a few other minor details

I also did some organising into blocks of Base/DiskArrays methods. 

A follow up PR will be to improve the documentation a little.
