### PR TITLE
add an `allow_scalar` method

### DIFF
--- a/src/DiskArrays.jl
+++ b/src/DiskArrays.jl
@@ -9,6 +9,7 @@ end DiskArrays
 
 export AbstractDiskArray, interpret_indices_disk, eachchunk, ChunkIndex, ChunkIndices
 
+include("scalar.jl")
 include("diskarray.jl")
 include("array.jl")
 include("broadcast.jl")

--- a/src/diskarray.jl
+++ b/src/diskarray.jl
@@ -25,8 +25,7 @@ function writeblock!() end
 function getindex_disk(a, i...)
     checkscalar(i)
     if any(j -> isa(j, AbstractArray) && !isa(j, AbstractRange), i)
-        batchgetindex(a, i...)
-    else
+        batchgetindex(a, i...) else
         inds, trans = interpret_indices_disk(a, i)
         data = Array{eltype(a)}(undef, map(length, inds)...)
         readblock!(a, data, inds...)
@@ -192,7 +191,7 @@ end
 
 macro implement_setindex(t)
     quote
-        Base.setindex!(a::$t, v, i...) = setindex_disk!(a, v, i...)
+        Base.setindex!(a::$t, v::AbstractArray, i...) = setindex_disk!(a, v, i...)
 
         # Add an extra method if a single number is given
         function Base.setindex!(a::$t{<:Any,N}, v, i...) where {N}

--- a/src/scalar.jl
+++ b/src/scalar.jl
@@ -1,4 +1,3 @@
-
 # Manual control over scalar indexing
 const ALLOW_SCALAR = Ref{Bool}(true)
 

--- a/src/scalar.jl
+++ b/src/scalar.jl
@@ -1,0 +1,30 @@
+
+# Manual control over scalar indexing
+const ALLOW_SCALAR = Ref{Bool}(true)
+
+"""
+    allow_scalar(x::Bool)
+
+Specify if a disk array can do scalar indexing, (with all `Int` arguments).
+
+Setting `allow_scalar(false)` can help identify the cause of poor performance.
+"""
+allow_scalar(x::Bool) = ALLOW_SCALAR[] = x
+
+"""
+    can_scalar()
+
+Check if DiskArrays is set to allow scalar indexing, with [`allow_scalar`](@ref).
+
+Returns a `Bool`.
+"""
+can_scalar() = ALLOW_SCALAR[]
+
+_scalar_error() = error("Scalar indexing with `Int` is very slow, and currently is disallowed. Run DiskArrays.allow_scalar(true) to allow")
+
+# Checks if an index is scalar at all, and then if scalar indexing is allowed. 
+# Syntax as for `checkbounds`.
+checkscalar(::Type{Bool}, I::Tuple) = checkscalar(Bool, I...) 
+checkscalar(::Type{Bool}, I...) = !all(map(i -> i isa Int, I)) || can_scalar()
+checkscalar(I::Tuple) = checkscalar(I...) 
+checkscalar(I...) = checkscalar(Bool, I...) || _scalar_error()


### PR DESCRIPTION
Introduce an optional check for scalar indexing as in CUDA.jl, using the CUDA.jl syntax.

This should help identify causes of performance bugs in future, e.g. in issues like https://github.com/rafaqz/Rasters.jl/issues/298