### PR TITLE
bugfix with JET

### DIFF
--- a/src/batchgetindex.jl
+++ b/src/batchgetindex.jl
@@ -189,7 +189,7 @@ function writeblock!(A::AbstractDiskArray, A_ret, r::AbstractVector...)
         return largest_jump > cs && length(ids) / (ma - mi) < 0.5
     end
     if any(need_batch)
-        batchsetindex!(a, v, i...)
+        batchsetindex!(A, A_ret, r...)
     else
         mi, ma = map(minimum, r), map(maximum, r)
         A_temp = similar(A_ret, map((a, b) -> b - a + 1, mi, ma))

--- a/src/iterator.jl
+++ b/src/iterator.jl
@@ -40,7 +40,9 @@ macro implement_iteration(t)
         Base.eachindex(a::$t) = BlockedIndices(eachchunk(a))
         function Base.iterate(a::$t)
             bi = BlockedIndices(eachchunk(a))
-            innernow, (chunkiter, innerinds) = iterate(bi)
+            it = iterate(bi)
+            isnothing(it) && return nothing
+            innernow, (chunkiter, innerinds) = it
             curchunk = innerinds.itr.indices
             datacur = OffsetArray(a[curchunk...], innerinds.itr)
             return datacur[innernow], (datacur, bi, (chunkiter, innerinds))

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -26,7 +26,7 @@ macro implement_mapreduce(t)
 
         function Base.mapfoldl_impl(f, op, nt::NamedTuple{()}, itr::$t)
             cc = eachchunk(itr)
-            isempty(cc) && return Base.mapreduce_empty_iter(f, op, itr, IteratorEltype(itr))
+            isempty(cc) && return Base.mapreduce_empty_iter(f, op, itr, Base.IteratorEltype(itr))
             return Base.mapfoldl_impl(f, op, nt, itr, cc)
         end
         function Base.mapfoldl_impl(f, op, nt::NamedTuple{()}, itr::$t, cc)


### PR DESCRIPTION
This is from running JET after `] activate .` in the DiskArrays.jl environment, with:

```julia
julia> JET.report_package(DiskArrays)
```

This PR cleans up most of the bugs,  although some would be good to have tests as well.
Still remaining are the expected "may throw" and some weirder deeply nested errors in Base, that seem to be problems in Base or JET more than here:

```julia
═════ 5 possible errors found ═════
┌ @ /home/raf/.julia/dev/DiskArrays/src/diskarray.jl:27 DiskArrays.batchgetindex(tuple(a), i...)
│┌ @ /home/raf/.julia/dev/DiskArrays/src/batchgetindex.jl:68 DiskArrays.batchgetindex(a, ci[i])
││┌ @ /home/raf/.julia/dev/DiskArrays/src/batchgetindex.jl:72 DiskArrays.disk_getindex_batch(a, indvec)
│││┌ @ /home/raf/.julia/dev/DiskArrays/src/batchgetindex.jl:119 prep = DiskArrays.prepare_disk_getindex_batch(ar, indstoread)
││││┌ @ /home/raf/.julia/dev/DiskArrays/src/batchgetindex.jl:78 inds = DiskArrays.collect(DiskArrays.Any, Base.OneTo(N))
│││││┌ @ array.jl:647 Base._collect(T, itr, Base.IteratorSize(itr))
││││││┌ @ array.jl:649 Base._array_for(T, isz, Base._similar_shape(itr, isz))
│││││││┌ @ array.jl:676 similar(Vector{Any}, axs)
││││││││┌ @ abstractarray.jl:840 similar(T, Base.to_shape(shape))
│││││││││┌ @ /home/raf/.julia/packages/OffsetArrays/WvkHl/src/OffsetArrays.jl:334 OffsetArrays.map(OffsetArrays._offset, OffsetArrays.axes(P), shape)
││││││││││┌ @ tuple.jl:250 map(f, Base.tail(t), Base.tail(s))
│││││││││││┌ @ tuple.jl:250 s[1]
││││││││││││┌ @ tuple.jl:29 Base.getfield(t, i, $(Expr(:boundscheck)))
│││││││││││││ invalid builtin function call
││││││││││││└───────────────
┌ @ /home/raf/.julia/dev/DiskArrays/src/diskarray.jl:65 DiskArrays.interpret_indices_disk(::Any, ::Tuple)
│ may throw: DiskArrays.throw(DiskArrays.ArgumentError(string("Indices of type ", DiskArrays.typeof(r::Tuple)::Type{<:Tuple}, " are not yet supported")::String)::ArgumentErr
or)::Union{}
└───────────────────────────────────────────────────────
┌ @ /home/raf/.julia/dev/DiskArrays/src/chunks.jl:84 throw(UndefKeywordError(:chunksizes))
│ UndefKeywordError: keyword argument chunksizes not assigned: throw(UndefKeywordError(:chunksizes)::UndefKeywordError)::Union{}
└────────────────────────────────────────────────────
┌ @ /home/raf/.julia/dev/DiskArrays/src/batchgetindex.jl:174 Base.materialize!(A_ret, Base.broadcasted(identity, DiskArrays.batchgetindex(tuple(A), r...)))
│┌ @ broadcast.jl:1175 val = Base.Broadcast.view(B.parent, B.mask)
││┌ @ subarray.jl:176 J = map(#185, to_indices(A, I))
│││┌ @ tuple.jl:221 f(t[1])
││││┌ @ subarray.jl:176 Base.unalias(getfield(#self#, :A), i)
│││││┌ @ abstractarray.jl:1427 Base.unaliascopy(A)
││││││┌ @ abstractarray.jl:1018 Base.copyto_unaliased!(IndexStyle(dest), dest, IndexStyle(src′), src′)
│││││││┌ @ abstractarray.jl:1043  = iterate(src)
││││││││┌ @ multidimensional.jl:778 iterate(L, tuple(1, r))
│││││││││┌ @ multidimensional.jl:811 Base.indexed_iterate(_3, 3, _5)
││││││││││┌ @ tuple.jl:88 Base.getfield(t, i)
│││││││││││ invalid builtin function call
││││││││││└───────────────
│││││││┌ @ abstractarray.jl:1045  = iterate(src, getfield(_9, 2))
││││││││┌ @ multidimensional.jl:811 Base.indexed_iterate(_3, 4, _5)
│││││││││┌ @ tuple.jl:88 Base.getfield(t, i)
││││││││││ invalid builtin function call
│││││││││└───────────────
```