### PR TITLE
bump patch version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiskArrays"
 uuid = "3c3547ce-8d99-4f5e-a174-61eb10b00ae3"
 authors = ["Fabian Gans <fgans@bgc-jena.mpg.de>"]
-version = "0.3.7"
+version = "0.3.8"
 
 [deps]
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"


### PR DESCRIPTION
Would be great to have #81 released such that ArchGDAL works on 1.9.