### PR TITLE
No batch mode for length 1 indices

### DIFF
--- a/src/diskarray.jl
+++ b/src/diskarray.jl
@@ -24,7 +24,7 @@ function writeblock!() end
 
 function getindex_disk(a, i...)
     checkscalar(i)
-    if any(j -> isa(j, AbstractArray) && !isa(j, AbstractRange), i)
+    if any(j -> isa(j, AbstractArray) && (length(j)>1) && !isa(j, AbstractRange), i)
         batchgetindex(a, i...) else
         inds, trans = interpret_indices_disk(a, i)
         data = Array{eltype(a)}(undef, map(length, inds)...)


### PR DESCRIPTION
This fixes an unnecessary call to the more expensive batchgetindex when indices along one dimension are arrays of length one. 