### PR TITLE
fix macros

### DIFF
--- a/src/DiskArrays.jl
+++ b/src/DiskArrays.jl
@@ -32,8 +32,8 @@ macro implement_diskarray(t)
         @implement_reshape $t
         @implement_array_methods $t
         @implement_permutedims $t
-        @implement_batchgetindex $t
         @implement_subarray $t
+        @implement_batchgetindex $t
     end
 end
 

--- a/src/DiskArrays.jl
+++ b/src/DiskArrays.jl
@@ -22,6 +22,7 @@ include("subarray.jl")
 # The all-in-one macro
 
 macro implement_diskarray(t)
+    t = esc(t)
     quote
         @implement_getindex $t
         @implement_setindex $t
@@ -31,6 +32,8 @@ macro implement_diskarray(t)
         @implement_reshape $t
         @implement_array_methods $t
         @implement_permutedims $t
+        @implement_batchgetindex $t
+        @implement_subarray $t
     end
 end
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -1,5 +1,6 @@
 
 macro implement_array_methods(t)
+    t = esc(t)
     quote
         Base.Array(a::$t) = DiskArrays._Array(a)
         Base.copyto!(dest::$t, source::AbstractArray) = DiskArrays._copyto!(dest, source)

--- a/src/batchgetindex.jl
+++ b/src/batchgetindex.jl
@@ -163,7 +163,7 @@ end
 shrinkaxis(a::Int, _) = a
 
 # Define fallbacks for reading and writing sparse data
-function readblock!(A::AbstractDiskArray, A_ret, r::AbstractVector...)
+function _readblock!(A, A_ret, r::AbstractVector...)
     #Check how sparse the vectors are, we look at the largest stride in the inputs
     need_batch = map(approx_chunksize(eachchunk(A)), r) do cs, ids
         length(ids) == 1 && return false
@@ -182,7 +182,7 @@ function readblock!(A::AbstractDiskArray, A_ret, r::AbstractVector...)
     return nothing
 end
 
-function writeblock!(A::AbstractDiskArray, A_ret, r::AbstractVector...)
+function _writeblock!(A, A_ret, r::AbstractVector...)
     #Check how sparse the vectors are, we look at the largest stride in the inputs
     need_batch = map(approx_chunksize(eachchunk(A)), r) do cs, ids
         length(ids) == 1 && return false
@@ -199,4 +199,18 @@ function writeblock!(A::AbstractDiskArray, A_ret, r::AbstractVector...)
         writeblock!(A, A_temp, map(:, mi, ma)...)
     end
     return nothing
+end
+
+macro implement_batchgetindex(t)
+    t = esc(t)
+    quote
+        # Define fallbacks for reading and writing sparse data
+        function readblock!(A::$t, A_ret, r::AbstractVector...)
+            _readblock!(A, A_ret, r...)
+        end
+
+        function writeblock!(A::$t, A_ret, r::AbstractVector...)
+            _writeblock!(A, A_ret, r...)
+        end
+    end
 end

--- a/src/batchgetindex.jl
+++ b/src/batchgetindex.jl
@@ -163,7 +163,7 @@ end
 shrinkaxis(a::Int, _) = a
 
 # Define fallbacks for reading and writing sparse data
-function _readblock!(A, A_ret, r::AbstractVector...)
+function _readblock!(A::AbstractArray, A_ret, r::AbstractVector...)
     #Check how sparse the vectors are, we look at the largest stride in the inputs
     need_batch = map(approx_chunksize(eachchunk(A)), r) do cs, ids
         length(ids) == 1 && return false
@@ -182,7 +182,7 @@ function _readblock!(A, A_ret, r::AbstractVector...)
     return nothing
 end
 
-function _writeblock!(A, A_ret, r::AbstractVector...)
+function _writeblock!(A::AbstractArray, A_ret, r::AbstractVector...)
     #Check how sparse the vectors are, we look at the largest stride in the inputs
     need_batch = map(approx_chunksize(eachchunk(A)), r) do cs, ids
         length(ids) == 1 && return false
@@ -205,11 +205,11 @@ macro implement_batchgetindex(t)
     t = esc(t)
     quote
         # Define fallbacks for reading and writing sparse data
-        function readblock!(A::$t, A_ret, r::AbstractVector...)
+        function DiskArrays.readblock!(A::$t, A_ret, r::AbstractVector...)
             _readblock!(A, A_ret, r...)
         end
 
-        function writeblock!(A::$t, A_ret, r::AbstractVector...)
+        function DiskArrays.writeblock!(A::$t, A_ret, r::AbstractVector...)
             _writeblock!(A, A_ret, r...)
         end
     end

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -129,6 +129,7 @@ splittuple(x1, xr...) = x1, xr
 # Implementation macro
 
 macro implement_broadcast(t)
+    t = esc(t)
     quote
         # Broadcasting with a DiskArray on LHS
         function Base.copyto!(dest::$t, bc::Broadcasted{Nothing})

--- a/src/diskarray.jl
+++ b/src/diskarray.jl
@@ -33,12 +33,12 @@ function getindex_disk(a, i...)
     end
 end
 
-function setindex_disk!(a::AbstractDiskArray{T}, v::T, i...) where {T<:AbstractArray}
+function setindex_disk!(a::AbstractArray{T}, v::T, i...) where {T<:AbstractArray}
     checkscalar(i)
     return setindex_disk!(a, [v], i...)
 end
 
-function setindex_disk!(a::AbstractDiskArray, v::AbstractArray, i...)
+function setindex_disk!(a::AbstractArray, v::AbstractArray, i...)
     checkscalar(i)
     if any(j -> isa(j, AbstractArray) && !isa(j, AbstractRange), i)
         batchsetindex!(a, v, i...)

--- a/src/diskarray.jl
+++ b/src/diskarray.jl
@@ -173,6 +173,7 @@ _convert_index(::Colon, s::Integer) = Base.OneTo(Int(s))
 include("chunks.jl")
 
 macro implement_getindex(t)
+    t = esc(t)
     quote
         Base.getindex(a::$t, i...) = getindex_disk(a, i...)
 
@@ -190,6 +191,7 @@ macro implement_getindex(t)
 end
 
 macro implement_setindex(t)
+    t = esc(t)
     quote
         Base.setindex!(a::$t, v::AbstractArray, i...) = setindex_disk!(a, v, i...)
 

--- a/src/iterator.jl
+++ b/src/iterator.jl
@@ -36,6 +36,7 @@ end
 # Implementaion macros
 
 macro implement_iteration(t)
+    t = esc(t)
     quote
         Base.eachindex(a::$t) = BlockedIndices(eachchunk(a))
         function Base.iterate(a::$t)

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -2,6 +2,7 @@
 # Implementation macro
 
 macro implement_mapreduce(t)
+    t = esc(t)
     quote
         function Base._mapreduce(f, op, v::$t)
             mapreduce(op, eachchunk(v)) do cI

--- a/src/permute.jl
+++ b/src/permute.jl
@@ -39,6 +39,7 @@ _getiperm(::PermutedDimsArray{<:Any,<:Any,<:Any,iperm}) where {iperm} = iperm
 # Implementaion macros
 
 macro implement_permutedims(t)
+    t = esc(t)
     quote
         Base.permutedims(parent::$t, perm) = permutedims_disk(parent, perm)
     end

--- a/src/reshape.jl
+++ b/src/reshape.jl
@@ -75,6 +75,7 @@ _ttgi(o, t, i1) = (o..., t[i1])
 # Implementaion macro
 
 macro implement_reshape(t)
+    t = esc(t)
     quote
         function Base._reshape(parent::$t, dims::NTuple{N,Int}) where {N}
             return reshape_disk(parent, dims)

--- a/src/subarray.jl
+++ b/src/subarray.jl
@@ -3,11 +3,6 @@ struct SubDiskArray{T,N} <: AbstractDiskArray{T,N}
 end
 
 # Base methods
-function Base.view(a::AbstractDiskArray, i...)
-    i2 = _replace_colon.(size(a), i)
-    return SubDiskArray(SubArray(a, i2))
-end
-Base.view(a::AbstractDiskArray, i::CartesianIndices) = view(a, i.indices...)
 function Base.view(a::SubDiskArray, i...)
     return SubDiskArray(view(a.v, i...))
 end
@@ -42,3 +37,16 @@ function eachchunk_view(::Chunked, vv)
 end
 eachchunk_view(::Unchunked, a) = estimate_chunksize(a)
 haschunks(a::SubDiskArray) = haschunks(parent(a.v))
+
+# Implementaion macro
+
+macro implement_subarray(t)
+    t = esc(t)
+    quote
+        function Base.view(a::$t, i...)
+            i2 = _replace_colon.(size(a), i)
+            return SubDiskArray(SubArray(a, i2))
+        end
+        Base.view(a::$t, i::CartesianIndices) = view(a, i.indices...)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,11 +21,12 @@ struct _DiskArray{T,N,A<:AbstractArray{T,N}} <: AbstractArray{T,N}
     parent::A
     chunksize::NTuple{N,Int}
 end
+_DiskArray(a; chunksize=size(a)) = _DiskArray(Ref(0), Ref(0), a, chunksize)
+
+# Apply the all in one macro rather than inheriting
 DiskArrays.@implement_diskarray _DiskArray
 
 Base.size(a::_DiskArray) = size(a.parent)
-
-_DiskArray(a; chunksize=size(a)) = _DiskArray(Ref(0), Ref(0), a, chunksize)
 DiskArrays.haschunks(::_DiskArray) = DiskArrays.Chunked()
 DiskArrays.eachchunk(a::_DiskArray) = DiskArrays.GridChunks(a, a.chunksize)
 getindex_count(a::_DiskArray) = a.getindex_count[]
@@ -41,16 +42,16 @@ function trueparent(
 ) where {T,N,perm,iperm}
     return permutedims(trueparent(a.a.parent), perm)
 end
-function DiskArrays.readblock!(a::_DiskArray, aout, i::OrdinalRange...)
+function DiskArrays.readblock!(a::_DiskArray, aout, i::AbstractUnitRange...)
     ndims(a) == length(i) || error("Number of indices is not correct")
-    all(r -> isa(r, OrdinalRange), i) || error("Not all indices are unit ranges")
+    all(r -> isa(r, AbstractUnitRange), i) || error("Not all indices are unit ranges")
     # println("reading from indices ", join(string.(i)," "))
     a.getindex_count[] += 1
     return aout .= a.parent[i...]
 end
-function DiskArrays.writeblock!(a::_DiskArray, v, i::OrdinalRange...)
+function DiskArrays.writeblock!(a::_DiskArray, v, i::AbstractUnitRange...)
     ndims(a) == length(i) || error("Number of indices is not correct")
-    all(r -> isa(r, OrdinalRange), i) || error("Not all indices are unit ranges")
+    all(r -> isa(r, AbstractUnitRange), i) || error("Not all indices are unit ranges")
     # println("Writing to indices ", join(string.(i)," "))
     a.setindex_count[] += 1
     return view(a.parent, i...) .= v
@@ -382,7 +383,7 @@ end
     #Index with range stride much larger than chunk size
     a = _DiskArray(reshape(1:100, 20, 5, 1); chunksize=(1, 5, 1))
     @test a[1:9:20, :, 1] == trueparent(a)[1:9:20, :, 1]
-    @test_broken getindex_count(a) == 3
+    @test getindex_count(a) == 3
 
     b = _DiskArray(zeros(4, 5, 1); chunksize=(4, 1, 1))
     b[[1, 4], [2, 5], 1] = ones(2, 2)
@@ -528,7 +529,7 @@ end
 
 struct TestArray{T,N} <: AbstractArray{T,N} end
 
-@testset "Macros" begin
+@testset "All macros apply" begin
     DiskArrays.@implement_getindex TestArray
     DiskArrays.@implement_setindex TestArray
     DiskArrays.@implement_broadcast TestArray


### PR DESCRIPTION
This PR fixes the escaping of all the macros so they work outside this package, and tests that macro application works.

I also had to define a few more macros for where `AbstractDiskArray` was used in dispatch - for views and batch indexing. 

@meggart I switch the test types to be from the the macro rather than inheriting from `AbstractDiskArray`.

But there is this one broken test I don't understand:

```julia
@test_broken getindex_count(a) == 3
```

I had to change `AbstractUnitRange` to `OrdinalRange` in the test methods once I used the macros. 

Any Ideas?