### PR TITLE
Undef array for batch indexing

### DIFF
--- a/src/batchgetindex.jl
+++ b/src/batchgetindex.jl
@@ -118,7 +118,7 @@ end
 
 function disk_getindex_batch(ar, indstoread)
     prep = prepare_disk_getindex_batch(ar, indstoread)
-    outar = OffsetArray(zeros(eltype(ar), prep.outsize...),prep.offsets...)
+    outar = OffsetArray(Array{eltype(ar)}(undef, prep.outsize...),prep.offsets...)
     return disk_getindex_batch!(outar, ar, indstoread; prep=prep)
 end
 


### PR DESCRIPTION
When creating OffsetArray for batch indexing, it would currently fail for arrays for which elements have no `zero` methods. For example, with the `_DiskArray` from the tests:
```julia
cda = _DiskArray(rand(Char, 3, 4))
cda[[1, 2], [2, 4]]
ERROR: MethodError: no method matching zero(::Type{Char})
Closest candidates are:
  zero(::Union{Type{P}, P}) where P<:Dates.Period at ~/julia-1.7.3/share/julia/stdlib/v1.7/Dates/src/periods.jl:53
  zero(::T) where T<:Dates.TimeType at ~/julia-1.7.3/share/julia/stdlib/v1.7/Dates/src/types.jl:450
  zero(::LinearAlgebra.UniformScaling{T}) where T at ~/julia-1.7.3/share/julia/stdlib/v1.7/LinearAlgebra/src/uniformscaling.jl:136
  ...
Stacktrace:
 [1] zeros(#unused#::Type{Char}, dims::Tuple{Int64, Int64})
   @ Base ./array.jl:526
 [2] zeros(::Type{Char}, ::Int64, ::Int64)
   @ Base ./array.jl:521
 [3] disk_getindex_batch(ar::_DiskArray{Char, 2, Matrix{Char}}, indstoread::Matrix{Tuple{Int64, Int64}})
   @ DiskArrays ~/.julia/dev/DiskArrays/src/batchgetindex.jl:121
 [4] batchgetindex(::_DiskArray{Char, 2, Matrix{Char}}, ::Vector{Int64}, ::Vector{Int64})
   @ DiskArrays ~/.julia/dev/DiskArrays/src/batchgetindex.jl:72
 [5] getindex_disk(::_DiskArray{Char, 2, Matrix{Char}}, ::Vector{Int64}, ::Vararg{Vector{Int64}})
   @ DiskArrays ~/.julia/dev/DiskArrays/src/diskarray.jl:28
 [6] getindex(::_DiskArray{Char, 2, Matrix{Char}}, ::Vector{Int64}, ::Vector{Int64})
   @ Main ~/.julia/dev/DiskArrays/src/diskarray.jl:178
```

This issue originated from [this discussion](https://github.com/Alexander-Barth/NCDatasets.jl/pull/205#issuecomment-1521546549)