### PR TITLE
add lazy concatenating disk arrays and Base.cat method

### DIFF
--- a/src/DiskArrays.jl
+++ b/src/DiskArrays.jl
@@ -18,6 +18,7 @@ include("mapreduce.jl")
 include("permute.jl")
 include("reshape.jl")
 include("subarray.jl")
+include("cat.jl")
 
 # The all-in-one macro
 
@@ -34,6 +35,7 @@ macro implement_diskarray(t)
         @implement_permutedims $t
         @implement_subarray $t
         @implement_batchgetindex $t
+        @implement_cat $t
     end
 end
 

--- a/src/cat.jl
+++ b/src/cat.jl
@@ -138,8 +138,12 @@ macro implement_cat(t)
     t = esc(t)
     quote
         # Allow mixed lazy cat of other arrays and disk arrays to still be lazy
+        # TODO this could be better. allowing non-AbstractDiskArray in
+        # the macro makes this kind of impossible to avoid dispatch problems
         Base.cat(A1::$t, As::AbstractArray...; dims::Int) = cat_disk(A1, As...; dims)
         Base.cat(A1::AbstractArray, A2::$t, As::AbstractArray...; dims::Int) = cat_disk(A1, A2, As...; dims)
         Base.cat(A1::$t, A2::$t, As::AbstractArray...; dims::Int) = cat_disk(A1, A2, As...; dims)
+        Base.vcat(A1::Union{$t{<:Any,1},$t{<:Any,2}}, As::Union{$t{<:Any,1},$t{<:Any,2}}...) = cat_disk(A1, As...; dims=1)
+        Base.hcat(A1::Union{$t{<:Any,1},$t{<:Any,2}}, As::Union{$t{<:Any,1},$t{<:Any,2}}...) = cat_disk(A1, As...; dims=2)
     end
 end

--- a/src/cat.jl
+++ b/src/cat.jl
@@ -114,7 +114,7 @@ function mergechunks_irregular(a, b)
     IrregularChunks(chunksizes = filter(!iszero, [length.(a); length.(b)]))
 end
 
-function cat_disk(As::AbstractDiskArray...; dims::Int)
+function cat_disk(As::AbstractArray...; dims::Int)
     sz = map(ntuple(identity, dims)) do i
         i == dims ? length(As) : 1
     end
@@ -127,8 +127,9 @@ end
 macro implement_cat(t)
     t = esc(t)
     quote
-        function Base.cat(A1::$t, As::$t...; dims::Int)
-            return cat_disk(A1, As...; dims)
-        end
+        # Allow mixed lazy cat of other arrays and disk arrays to still be lazy
+        Base.cat(A1::$t, As::AbstractArray...; dims::Int) = cat_disk(A1, As...; dims)
+        Base.cat(A1::AbstractArray, A2::$t, As::AbstractArray...; dims::Int) = cat_disk(A1, A2, As...; dims)
+        Base.cat(A1::$t, A2::$t, As::AbstractArray...; dims::Int) = cat_disk(A1, A2, As...; dims)
     end
 end

--- a/src/cat.jl
+++ b/src/cat.jl
@@ -1,0 +1,134 @@
+
+"""
+    ConcatDiskArray <: AbstractDiskArray
+
+Joins multiple AbstractArrays or AbstractDiskArrays in lazy concatination.
+"""
+struct ConcatDiskArray{T,N,P} <: AbstractDiskArray{T,N}
+    parents::P
+    startinds::NTuple{N,Vector{Int}}
+    size::NTuple{N,Int}
+end
+function ConcatDiskArray(arrays::AbstractArray{<:AbstractArray{T,N},M}) where {T,N,M}
+    function othersize(x, id)
+        (x[1:id-1]..., x[id+1:end]...)
+    end
+    if N > M
+        newshape = (size(arrays)..., ntuple(_ -> 1, N - M)...)
+        arrays1 = reshape(arrays, newshape)
+        D = N
+    elseif N < M
+        arrays1 = map(arrays) do a
+            newshape = (size(a)..., ntuple(_ -> 1, M - N)...)
+            reshape(a, newshape)
+        end
+        D = M
+    else
+        arrays1 = arrays
+        D = M
+    end
+    arraysizes = map(size, arrays1)
+    si = ntuple(D) do id
+        a = reduce(arraysizes; dims=id, init=ntuple(zero, D)) do i, j
+            if all(iszero, i)
+                j
+            elseif othersize(i, id) == othersize(j, id)
+                j
+            else
+                error("Dimension sizes don't match")
+            end
+        end
+        I = ntuple(D) do i
+            i == id ? Colon() : 1
+        end
+        ari = map(i -> i[id], arraysizes[I...])
+        sl = sum(ari)
+        r = cumsum(ari)
+        pop!(pushfirst!(r, 0))
+        r .+ 1, sl
+    end
+
+    startinds = map(first, si)
+    sizes = map(last, si)
+
+    return ConcatDiskArray{T,D,typeof(arrays1)}(arrays1, startinds, sizes)
+end
+function ConcatDiskArray(arrays::AbstractArray)
+    # Validate array eltype and dimensionality
+    all(t -> t == eltype(first(arrays)), eltypes) || error("Arrays don't have the same element type")
+    all(s -> length(s) == ndims(first(arrays)), sizes) || error("Arrays don't have the same dimensions")
+    error("Should not be reached")
+end
+
+Base.size(a::ConcatDiskArray) = a.size
+
+function readblock!(a::ConcatDiskArray, aout, inds::AbstractUnitRange...)
+    # Find affected blocks and indices in blocks
+    blockinds = map(inds, a.startinds, size(a.parents)) do i, si, s
+        bi1 = max(searchsortedlast(si, first(i)), 1)
+        bi2 = min(searchsortedfirst(si, last(i) + 1) - 1, s)
+        bi1:bi2
+    end
+    map(CartesianIndices(blockinds)) do cI
+        myar = a.parents[cI]
+        mysize = size(myar)
+        array_range = map(cI.I, a.startinds, mysize, inds) do ii, si, ms, indstoread
+            max(first(indstoread) - si[ii] + 1, 1):min(last(indstoread) - si[ii] + 1, ms)
+        end
+        outer_range = map(cI.I, a.startinds, array_range, inds) do ii, si, ar, indstoread
+            (first(ar)+si[ii]-first(indstoread)):(last(ar)+si[ii]-first(indstoread))
+        end
+        aout[outer_range...] = a.parents[cI][array_range...]
+    end
+end
+
+function writeblock!(a::ConcatDiskArray, aout, inds::AbstractUnitRange...)
+    error("No method yet for writing into a ConcatDiskArray")
+end
+
+haschunks(::ConcatDiskArray) = Chunked()
+
+function eachchunk(aconc::ConcatDiskArray{T,N}) where {T,N}
+    s = size(aconc)
+    oldchunks = map(eachchunk, aconc.parents)
+    newchunks = ntuple(N) do i
+        sliceinds = Base.setindex(ntuple(_ -> 1, N), :, i)
+        v = map(c -> c.chunks[i], oldchunks[sliceinds...])
+        init = RegularChunks(approx_chunksize(first(v)), 0, 0)
+        reduce(mergechunks, v; init = init)
+    end
+
+    return GridChunks(newchunks...)
+end
+
+function mergechunks(a::RegularChunks, b::RegularChunks)
+    if a.s == 0 || (a.cs == b.cs && length(last(a)) == a.cs)
+        RegularChunks(a.cs, a.offset, a.s + b.s)
+    else
+        mergechunks_irregular(a, b)
+    end
+end
+
+mergechunks(a::ChunkType, b::ChunkType) = mergechunks_irregular(a, b)
+function mergechunks_irregular(a, b)
+    IrregularChunks(chunksizes = filter(!iszero, [length.(a); length.(b)]))
+end
+
+function cat_disk(As::AbstractDiskArray...; dims::Int)
+    sz = map(ntuple(identity, dims)) do i
+        i == dims ? length(As) : 1
+    end
+    cdas = reshape(collect(As), sz)
+    return ConcatDiskArray(cdas)
+end
+
+# Implementation macro
+
+macro implement_cat(t)
+    t = esc(t)
+    quote
+        function Base.cat(A1::$t, As::$t...; dims::Int)
+            return cat_disk(A1, As...; dims)
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,7 +14,6 @@ using Statistics
     @test DiskArrays.checkscalar(Bool, :, 2:5, 3) == true
 end
 
-
 # Define a data structure that can be used for testing
 struct _DiskArray{T,N,A<:AbstractArray{T,N}} <: AbstractArray{T,N}
     getindex_count::Ref{Int}
@@ -313,7 +312,6 @@ end
 
 @testset "AbstractDiskArray getindex" begin
     a = _DiskArray(reshape(1:20, 4, 5, 1))
-    test_getindex(a)
     test_getindex(a)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -361,11 +361,32 @@ end
         @test collect(cat(a, b; dims=4)) == cat(collect(a), collect(b); dims=4)
         @test collect(cat(a, b; dims=5)) == cat(collect(a), collect(b); dims=5)
     end
+
     @testset "cat mixed arrays and disk arrays is still a ConcatDiskArray" begin
         @test cat(a, collect(b); dims=1) isa DiskArrays.ConcatDiskArray
         @test collect(cat(a, collect(b); dims=1)) == cat(collect(a), collect(b); dims=1)
         @test cat(collect(a), b; dims=1) isa DiskArrays.ConcatDiskArray
         @test collect(cat(collect(a), b; dims=1)) == cat(collect(a), collect(b); dims=1)
+    end
+
+    @testset "cat mixed chunk size" begin
+        a = _DiskArray(1:10; chunksize=(3,))
+        b = _DiskArray(1:9; chunksize=(4,))
+        c = cat(a, b, a; dims=1)
+        @test c == [1:10; 1:9; 1:10]
+        @test DiskArrays.eachchunk(c) == [
+             (1:3,)
+             (4:6,)
+             (7:9,)
+             (10:10,)
+             (11:14,)
+             (15:18,)
+             (19:19,)
+             (20:22,)
+             (23:25,)
+             (26:28,)
+             (29:29,)
+        ]
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -354,11 +354,19 @@ end
     @test ca == da
     @test ca .* 2 == da .* 2
 
-    @test collect(cat(a, b; dims=1)) == cat(collect(a), collect(b); dims=1)
-    @test collect(cat(a, b; dims=2)) == cat(collect(a), collect(b); dims=2)
-    @test collect(cat(a, b; dims=3)) == cat(collect(a), collect(b); dims=3)
-    @test collect(cat(a, b; dims=4)) == cat(collect(a), collect(b); dims=4)
-    @test collect(cat(a, b; dims=5)) == cat(collect(a), collect(b); dims=5)
+    @testset "cat on all dims" begin
+        @test collect(cat(a, b; dims=1)) == cat(collect(a), collect(b); dims=1)
+        @test collect(cat(a, b; dims=2)) == cat(collect(a), collect(b); dims=2)
+        @test collect(cat(a, b; dims=3)) == cat(collect(a), collect(b); dims=3)
+        @test collect(cat(a, b; dims=4)) == cat(collect(a), collect(b); dims=4)
+        @test collect(cat(a, b; dims=5)) == cat(collect(a), collect(b); dims=5)
+    end
+    @testset "cat mixed arrays and disk arrays is still a ConcatDiskArray" begin
+        @test cat(a, collect(b); dims=1) isa DiskArrays.ConcatDiskArray
+        @test collect(cat(a, collect(b); dims=1)) == cat(collect(a), collect(b); dims=1)
+        @test cat(collect(a), b; dims=1) isa DiskArrays.ConcatDiskArray
+        @test collect(cat(collect(a), b; dims=1)) == cat(collect(a), collect(b); dims=1)
+    end
 end
 
 @testset "Broadcast with length 1 and 0 final dim" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -369,7 +369,7 @@ end
         @test collect(cat(collect(a), b; dims=1)) == cat(collect(a), collect(b); dims=1)
     end
 
-    @testset "write concat"
+   @testset "write concat" begin
         ca .= reshape(0:23, 4, 6)
         @test sum(ca) == sum(0:23)
     end
@@ -380,7 +380,7 @@ end
         c = _DiskArray(collect(1:7); chunksize=(3,))
         d = cat(a, b, c; dims=1)
         @test d == [1:10; 1:9; 1:7]
-        @test DiskArrays.eachchunk(c) == [
+        @test DiskArrays.eachchunk(d) == [
              (1:3,)
              (4:6,)
              (7:9,)
@@ -390,8 +390,7 @@ end
              (19:19,)
              (20:22,)
              (23:25,)
-             (26:28,)
-             (29:29,)
+             (26:26,)
         ]
         d .= 1:26
         @test d == 1:26

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,7 @@ using Statistics
     @test DiskArrays.checkscalar(Bool, :, 2:5, 3) == true
 end
 
+
 # Define a data structure that can be used for testing
 struct _DiskArray{T,N,A<:AbstractArray{T,N}} <: AbstractArray{T,N}
     getindex_count::Ref{Int}
@@ -313,6 +314,7 @@ end
 @testset "AbstractDiskArray getindex" begin
     a = _DiskArray(reshape(1:20, 4, 5, 1))
     test_getindex(a)
+    test_getindex(a)
 end
 
 @testset "AbstractDiskArray setindex" begin
@@ -344,6 +346,21 @@ end
 @testset "Broadcast" begin
     a_disk1 = _DiskArray(rand(10, 9, 2); chunksize=(5, 3, 2))
     test_broadcast(a_disk1)
+end
+
+@testset "cat" begin
+    da = _DiskArray(reshape(1:24, 4, 6, 1))
+    a = view(da, :, 1:3, :) 
+    b = view(da, :, 4:6, :) 
+    ca = cat(a, b; dims=2)
+    @test ca == da
+    @test ca .* 2 == da .* 2
+
+    @test collect(cat(a, b; dims=1)) == cat(collect(a), collect(b); dims=1)
+    @test collect(cat(a, b; dims=2)) == cat(collect(a), collect(b); dims=2)
+    @test collect(cat(a, b; dims=3)) == cat(collect(a), collect(b); dims=3)
+    @test collect(cat(a, b; dims=4)) == cat(collect(a), collect(b); dims=4)
+    @test collect(cat(a, b; dims=5)) == cat(collect(a), collect(b); dims=5)
 end
 
 @testset "Broadcast with length 1 and 0 final dim" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -347,7 +347,7 @@ end
 end
 
 @testset "cat" begin
-    da = _DiskArray(reshape(1:24, 4, 6, 1))
+    da = _DiskArray(collect(reshape(1:24, 4, 6, 1)))
     a = view(da, :, 1:3, :) 
     b = view(da, :, 4:6, :) 
     ca = cat(a, b; dims=2)
@@ -369,11 +369,17 @@ end
         @test collect(cat(collect(a), b; dims=1)) == cat(collect(a), collect(b); dims=1)
     end
 
+    @testset "write concat"
+        ca .= reshape(0:23, 4, 6)
+        @test sum(ca) == sum(0:23)
+    end
+
     @testset "cat mixed chunk size" begin
-        a = _DiskArray(1:10; chunksize=(3,))
-        b = _DiskArray(1:9; chunksize=(4,))
-        c = cat(a, b, a; dims=1)
-        @test c == [1:10; 1:9; 1:10]
+        a = _DiskArray(collect(1:10); chunksize=(3,))
+        b = _DiskArray(collect(1:9); chunksize=(4,))
+        c = _DiskArray(collect(1:7); chunksize=(3,))
+        d = cat(a, b, c; dims=1)
+        @test d == [1:10; 1:9; 1:7]
         @test DiskArrays.eachchunk(c) == [
              (1:3,)
              (4:6,)
@@ -387,6 +393,9 @@ end
              (26:28,)
              (29:29,)
         ]
+        d .= 1:26
+        @test d == 1:26
+        @test c == 20:26
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -486,9 +486,12 @@ end
     @test median(a_disk) == median(a)
     @test median(a_disk; dims=1) == median(a; dims=1) # Works but very slow
     @test median(a_disk; dims=2) == median(a; dims=2) # Works but very slow
-    @test_broken vcat(a_disk, a_disk) == vcat(a, a) # Wrong answer because `iterate` is broken
-    @test_broken hcat(a_disk, a_disk) == hcat(a, a) # Wrong answer because `iterate` is broken
-    @test_broken cat(a_disk, a_disk; dims=3) == cat(a, a; dims=3) # Wrong answer because `iterate` is broken
+    @test collect(vcat(a_disk, a_disk)) == vcat(a, a) # Needs collect because `zip` is broken
+    @test collect(hcat(a_disk, a_disk)) == hcat(a, a) # Needs collect because `zip` is broken
+    @test collect(cat(a_disk, a_disk; dims=3)) == cat(a, a; dims=3) # Needs collect because `zip` is broken
+    @test_broken vcat(a_disk, a_disk) == vcat(a, a)
+    @test_broken hcat(a_disk, a_disk) == hcat(a, a)
+    @test_broken cat(a_disk, a_disk; dims=3) == cat(a, a; dims=3)
     @test_broken circshift(a_disk, 2) == circshift(a, 2) # This one is super weird. The size changes.
 end
 


### PR DESCRIPTION
This is half code modified from DiskArrayTools.jl

It adds a `ConcatDiskArray` wrapper, and a `cat` method that applies it.

We could possibly try to merge if a `ConcatDiskArray` is passed to the `ConcatDiskArray` constructor? 