### PR TITLE
fix zip

### DIFF
--- a/src/DiskArrays.jl
+++ b/src/DiskArrays.jl
@@ -18,7 +18,9 @@ include("mapreduce.jl")
 include("permute.jl")
 include("reshape.jl")
 include("subarray.jl")
+include("rechunk.jl")
 include("cat.jl")
+include("zip.jl")
 
 # The all-in-one macro
 
@@ -36,6 +38,7 @@ macro implement_diskarray(t)
         @implement_subarray $t
         @implement_batchgetindex $t
         @implement_cat $t
+        @implement_zip $t
     end
 end
 

--- a/src/DiskArrays.jl
+++ b/src/DiskArrays.jl
@@ -25,6 +25,7 @@ include("zip.jl")
 # The all-in-one macro
 
 macro implement_diskarray(t)
+    # Need to do this for dispatch ambiguity
     t = esc(t)
     quote
         @implement_getindex $t
@@ -42,6 +43,17 @@ macro implement_diskarray(t)
     end
 end
 
-@implement_diskarray AbstractDiskArray
+# We need to skip the `implement_zip` macro for dispatch
+@implement_getindex AbstractDiskArray
+@implement_setindex AbstractDiskArray
+@implement_broadcast AbstractDiskArray
+@implement_iteration AbstractDiskArray
+@implement_mapreduce AbstractDiskArray
+@implement_reshape AbstractDiskArray
+@implement_array_methods AbstractDiskArray
+@implement_permutedims AbstractDiskArray
+@implement_subarray AbstractDiskArray
+@implement_batchgetindex AbstractDiskArray
+@implement_cat AbstractDiskArray
 
 end # module

--- a/src/rechunk.jl
+++ b/src/rechunk.jl
@@ -1,0 +1,16 @@
+# Force disk any abstractarray into a different chunking pattern.
+# This is useful in `zip` and other operations that can iterate
+# over multiple arrays with different patterns.
+
+struct RechunkedDiskArray{T,N,A<:AbstractArray{T,N},C} <: AbstractDiskArray{T,N}
+    parent::A
+    chunks::C
+end
+
+Base.parent(A::RechunkedDiskArray) = A.parent
+Base.size(A::RechunkedDiskArray) = size(parent(A))
+Base.getindex(A::RechunkedDiskArray, I...) = getindex(parent(A), I...)
+Base.setindex!(A::RechunkedDiskArray, I...) = setindex!(parent(A), I...)
+
+haschunks(::RechunkedDiskArray) = Chunked()
+eachchunk(A::RechunkedDiskArray) = A.chunks

--- a/src/zip.jl
+++ b/src/zip.jl
@@ -1,6 +1,9 @@
 
-# Rechunk using the chunks of the first 
+# Rechunk using the chunks of the first Chunked array
+# This forces the iteration order to be the same for 
+# all arrays.
 function zip_disk(As...)
+    # Get the chunkes of the first Chunked array
     chunks = reduce(As; init=nothing) do acc, A
         if acc == nothing && haschunks(A) == Chunked() 
             eachchunk(A) 
@@ -9,19 +12,38 @@ function zip_disk(As...)
         end
     end
     if isnothing(chunks)
-        chunks = eachchunk(first(As))
+        return Base.Iterators.Zip(As)
+    else
+        rechunked = map(As) do A
+            RechunkedDiskArray(A, chunks)
+        end
+        return Base.Iterators.Zip(rechunked)
     end
-    rechunked = map(As) do A
-        RechunkedDiskArray(A, chunks)
-    end
-    return Base.Iterators.Zip(rechunked)
 end
+
+_zip_error() = throw(ArgumentError("Cannot `zip` a disk array with an iterator"))
+
+Base.zip(A1::AbstractDiskArray, A2::AbstractDiskArray, As::AbstractArray...) = zip_disk(A1, A2, As...)
+Base.zip(A1::AbstractDiskArray, A2::AbstractArray, As::AbstractArray...) = zip_disk(A1, A1, As...)
+Base.zip(A1::AbstractArray, A2::AbstractDiskArray, As::AbstractArray...) = zip_disk(A1, A2, As...)
+
+Base.zip(::AbstractDiskArray, x, xs...) = _zip_error()
+Base.zip(x, ::AbstractDiskArray, xs...) = _zip_error()
+Base.zip(x::AbstractDiskArray, ::AbstractDiskArray, xs...) = _zip_error()
 
 macro implement_zip(t)
     t = esc(t)
     quote
-        Base.zip(A1::$t, As::AbstractArray...) = zip_disk(A1, As...)
-        Base.zip(A1::AbstractArray, A2::$t, As::AbstractArray...) = zip_disk(A1, A2, As...)
-        Base.zip(A1::$t, A2::$t, As::AbstractArray...) = zip_disk(A1, A2, As...)
+        Base.zip(A1::$t, A2::$t, As::AbstractArray...) = $zip_disk(A1, A1, As...)
+        Base.zip(A1::$t, A2::AbstractArray, As::AbstractArray...) = $zip_disk(A1, A2, As...)
+        Base.zip(A1::AbstractArray, A2::$t, As::AbstractArray...) = $zip_disk(A1, A2, As...)
+
+        Base.zip(A1::AbstractDiskArray, A2::$t, As::AbstractArray...) = $zip_disk(A1, A2, As...)
+        Base.zip(A1::$t, A2::AbstractDiskArray, As::AbstractArray...) = $zip_disk(A1, A2, As...)
+
+        Base.zip(::$t, x, xs...) = $_zip_error()
+        Base.zip(x, ::$t, xs...) = $_zip_error()
+        Base.zip(x, ::$t, xs...) = $_zip_error()
     end
 end
+

--- a/src/zip.jl
+++ b/src/zip.jl
@@ -65,7 +65,7 @@ Base.zip(x::AbstractDiskArray, ::AbstractDiskArray, xs...) = _zip_error()
 macro implement_zip(t)
     t = esc(t)
     quote
-        Base.zip(A1::$t, A2::$t, As::AbstractArray...) = $DiskZip(A1, A1, As...)
+        Base.zip(A1::$t, A2::$t, As::AbstractArray...) = $DiskZip(A1, A2, As...)
         Base.zip(A1::$t, A2::AbstractArray, As::AbstractArray...) = $DiskZip(A1, A2, As...)
         Base.zip(A1::AbstractArray, A2::$t, As::AbstractArray...) = $DiskZip(A1, A2, As...)
 

--- a/src/zip.jl
+++ b/src/zip.jl
@@ -1,0 +1,27 @@
+
+# Rechunk using the chunks of the first 
+function zip_disk(As...)
+    chunks = reduce(As; init=nothing) do acc, A
+        if acc == nothing && haschunks(A) == Chunked() 
+            eachchunk(A) 
+        else
+            nothing
+        end
+    end
+    if isnothing(chunks)
+        chunks = eachchunk(first(As))
+    end
+    rechunked = map(As) do A
+        RechunkedDiskArray(A, chunks)
+    end
+    return Base.Iterators.Zip(rechunked)
+end
+
+macro implement_zip(t)
+    t = esc(t)
+    quote
+        Base.zip(A1::$t, As::AbstractArray...) = zip_disk(A1, As...)
+        Base.zip(A1::AbstractArray, A2::$t, As::AbstractArray...) = zip_disk(A1, A2, As...)
+        Base.zip(A1::$t, A2::$t, As::AbstractArray...) = zip_disk(A1, A2, As...)
+    end
+end

--- a/src/zip.jl
+++ b/src/zip.jl
@@ -18,6 +18,9 @@ Base.IteratorEltype(::Type{DiskZip{Is}}) where {Is<:Tuple} =
 # all arrays.
 
 function DiskZip(As::AbstractArray{<:Any,N}...) where N
+    map(As) do A
+        size(A) == size(first(As)) || throw(DimensionMismatch("Arrays zipped with disk arrays must be the same size"))
+    end
     # Get the chunkes of the first Chunked array
     chunks = reduce(As; init=nothing) do acc, A
         if isnothing(acc) && (haschunks(A) isa Chunked)

--- a/src/zip.jl
+++ b/src/zip.jl
@@ -43,8 +43,7 @@ DiskZip(As...) = throw(ArgumentError("zip on disk arrays only works with other s
 
 # Collect zipped disk arrays in the right order
 function Base.collect(z::DiskZip)
-    shp = Base._similar_shape(z, Iterators.IteratorSize(z))
-    out = Base._similar_for(1:1, eltype(z), z, Iterators.IteratorSize(z), shp)
+    out = similar(first(z.is), eltype(z))
     itr = iterate(z)
     for I in eachindex(first(z.is))
         out[I] = first(itr)

--- a/src/zip.jl
+++ b/src/zip.jl
@@ -1,31 +1,60 @@
 
+struct DiskZip{Is<:Tuple}
+    is::Is
+end
+Base.iterate(dz::DiskZip) = Base.iterate(Iterators.Zip(dz.is))
+Base.iterate(dz::DiskZip, i) = Base.iterate(Iterators.Zip(dz.is), i)
+Base.first(dz::DiskZip) = Base.first(Iterators.Zip(dz.is))
+Base.last(dz::DiskZip) = Base.last(Iterators.Zip(dz.is))
+Base.length(dz::DiskZip) = Base.length(Iterators.Zip(dz.is))
+Base.size(dz::DiskZip) = Base.size(Iterators.Zip(dz.is))
+Base.IteratorSize(::Type{DiskZip{Is}}) where {Is<:Tuple} =
+    Base.IteratorSize(Iterators.Zip{Is})
+Base.IteratorEltype(::Type{DiskZip{Is}}) where {Is<:Tuple} =
+    Base.IteratorEltype(Iterators.Zip{Is})
+
 # Rechunk using the chunks of the first Chunked array
-# This forces the iteration order to be the same for 
+# This forces the iteration order to be the same for
 # all arrays.
-function zip_disk(As...)
+
+function DiskZip(As::AbstractArray{<:Any,N}...) where N
     # Get the chunkes of the first Chunked array
     chunks = reduce(As; init=nothing) do acc, A
-        if acc == nothing && haschunks(A) == Chunked() 
-            eachchunk(A) 
+        if isnothing(acc) && (haschunks(A) isa Chunked)
+            eachchunk(A)
         else
-            nothing
+            acc
         end
     end
     if isnothing(chunks)
-        return Base.Iterators.Zip(As)
+        return DiskZip(As)
     else
         rechunked = map(As) do A
             RechunkedDiskArray(A, chunks)
         end
-        return Base.Iterators.Zip(rechunked)
+        return DiskZip(rechunked)
     end
+end
+# For now we only allow zip on exact same-sized arrays
+DiskZip(As...) = throw(ArgumentError("zip on disk arrays only works with other same-sized AbstractArray"))
+
+# Collect zipped disk arrays in the right order
+function Base.collect(z::DiskZip)
+    shp = Base._similar_shape(z, Iterators.IteratorSize(z))
+    out = Base._similar_for(1:1, eltype(z), z, Iterators.IteratorSize(z), shp)
+    itr = iterate(z)
+    for I in eachindex(first(z.is))
+        out[I] = first(itr)
+        itr = iterate(z, last(itr))
+    end
+    return out
 end
 
 _zip_error() = throw(ArgumentError("Cannot `zip` a disk array with an iterator"))
 
-Base.zip(A1::AbstractDiskArray, A2::AbstractDiskArray, As::AbstractArray...) = zip_disk(A1, A2, As...)
-Base.zip(A1::AbstractDiskArray, A2::AbstractArray, As::AbstractArray...) = zip_disk(A1, A1, As...)
-Base.zip(A1::AbstractArray, A2::AbstractDiskArray, As::AbstractArray...) = zip_disk(A1, A2, As...)
+Base.zip(A1::AbstractDiskArray, A2::AbstractDiskArray, As::AbstractArray...) = DiskZip(A1, A2, As...)
+Base.zip(A1::AbstractDiskArray, A2::AbstractArray, As::AbstractArray...) = DiskZip(A1, A1, As...)
+Base.zip(A1::AbstractArray, A2::AbstractDiskArray, As::AbstractArray...) = DiskZip(A1, A2, As...)
 
 Base.zip(::AbstractDiskArray, x, xs...) = _zip_error()
 Base.zip(x, ::AbstractDiskArray, xs...) = _zip_error()
@@ -34,16 +63,15 @@ Base.zip(x::AbstractDiskArray, ::AbstractDiskArray, xs...) = _zip_error()
 macro implement_zip(t)
     t = esc(t)
     quote
-        Base.zip(A1::$t, A2::$t, As::AbstractArray...) = $zip_disk(A1, A1, As...)
-        Base.zip(A1::$t, A2::AbstractArray, As::AbstractArray...) = $zip_disk(A1, A2, As...)
-        Base.zip(A1::AbstractArray, A2::$t, As::AbstractArray...) = $zip_disk(A1, A2, As...)
+        Base.zip(A1::$t, A2::$t, As::AbstractArray...) = $DiskZip(A1, A1, As...)
+        Base.zip(A1::$t, A2::AbstractArray, As::AbstractArray...) = $DiskZip(A1, A2, As...)
+        Base.zip(A1::AbstractArray, A2::$t, As::AbstractArray...) = $DiskZip(A1, A2, As...)
 
-        Base.zip(A1::AbstractDiskArray, A2::$t, As::AbstractArray...) = $zip_disk(A1, A2, As...)
-        Base.zip(A1::$t, A2::AbstractDiskArray, As::AbstractArray...) = $zip_disk(A1, A2, As...)
+        Base.zip(A1::AbstractDiskArray, A2::$t, As::AbstractArray...) = $DiskZip(A1, A2, As...)
+        Base.zip(A1::$t, A2::AbstractDiskArray, As::AbstractArray...) = $DiskZip(A1, A2, As...)
 
         Base.zip(::$t, x, xs...) = $_zip_error()
         Base.zip(x, ::$t, xs...) = $_zip_error()
         Base.zip(x, ::$t, xs...) = $_zip_error()
     end
 end
-

--- a/src/zip.jl
+++ b/src/zip.jl
@@ -42,12 +42,12 @@ end
 DiskZip(As...) = throw(ArgumentError("zip on disk arrays only works with other same-sized AbstractArray"))
 
 # Collect zipped disk arrays in the right order
-function Base.collect(z::DiskZip)
-    out = similar(first(z.is), eltype(z))
-    itr = iterate(z)
-    for I in eachindex(first(z.is))
-        out[I] = first(itr)
-        itr = iterate(z, last(itr))
+function Base.collect(dz::DiskZip)
+    out = similar(first(dz.is), eltype(dz))
+    i = iterate(dz)
+    for I in eachindex(first(dz.is))
+        out[I] = first(i)
+        i = iterate(dz, last(i))
     end
     return out
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -346,6 +346,28 @@ end
     test_broadcast(a_disk1)
 end
 
+@testset "zip" begin
+    da = _DiskArray(rand(10, 9, 2); chunksize=(5, 3, 2))
+    a = collect(da)
+    zd = zip(da, da)
+    za = zip(a, a)
+    @test collect(zd) == collect(za)
+    @test all(zd .== za)
+    a = collect(da)
+    @test zip(a, da, a) isa DiskArrays.DiskZip
+    @test zip(da, da, a) isa DiskArrays.DiskZip
+    @test zip(da, da, da) isa DiskArrays.DiskZip
+    @test zip(a, da, da) isa DiskArrays.DiskZip
+    # Should we add moree dispatch to fix this?
+    @test_broken zip(a, a, da) isa DiskArrays.DiskZip
+    zd3_a = zip(a, da, a)
+    zd3_b = zip(da, da, a)
+    zd3_c = zip(da, a, a)
+    za3 = zip(a, a, a)
+    @test collect(zd3_a) == collect(zd3_b) == collect(zd3_c) == collect(za3)
+    @test all(zd3_a .== zd3_b .== zd3_c .== za3)
+end
+
 @testset "cat" begin
     da = _DiskArray(collect(reshape(1:24, 4, 6, 1)))
     a = view(da, :, 1:3, :) 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -350,7 +350,7 @@ end
     a = rand(10, 9, 2)
     b = rand(10, 9, 2)
     da = _DiskArray(a; chunksize=(5, 3, 2));
-    db = _DiskArray(b; chunksize=(5, 3, 2));
+    db = _DiskArray(b; chunksize=(2, 3, 1));
     z = zip(a, b)
     zd = zip(da, db)
     zdc = collect(zd) 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -486,12 +486,9 @@ end
     @test median(a_disk) == median(a)
     @test median(a_disk; dims=1) == median(a; dims=1) # Works but very slow
     @test median(a_disk; dims=2) == median(a; dims=2) # Works but very slow
-    @test collect(vcat(a_disk, a_disk)) == vcat(a, a) # Needs collect because `zip` is broken
-    @test collect(hcat(a_disk, a_disk)) == hcat(a, a) # Needs collect because `zip` is broken
-    @test collect(cat(a_disk, a_disk; dims=3)) == cat(a, a; dims=3) # Needs collect because `zip` is broken
-    @test_broken vcat(a_disk, a_disk) == vcat(a, a)
-    @test_broken hcat(a_disk, a_disk) == hcat(a, a)
-    @test_broken cat(a_disk, a_disk; dims=3) == cat(a, a; dims=3)
+    @test vcat(a_disk, a_disk) == vcat(a, a)
+    @test hcat(a_disk, a_disk) == hcat(a, a)
+    @test cat(a_disk, a_disk; dims=3) == cat(a, a; dims=3)
     @test_broken circshift(a_disk, 2) == circshift(a, 2) # This one is super weird. The size changes.
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -366,6 +366,7 @@ end
     za3 = zip(a, a, a)
     @test collect(zd3_a) == collect(zd3_b) == collect(zd3_c) == collect(za3)
     @test all(zd3_a .== zd3_b .== zd3_c .== za3)
+    @test_throws DimensionMismatch zip(da, rand(2, 3, 1))
 end
 
 @testset "cat" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -347,13 +347,18 @@ end
 end
 
 @testset "zip" begin
-    da = _DiskArray(rand(10, 9, 2); chunksize=(5, 3, 2))
-    a = collect(da)
-    zd = zip(da, da)
-    za = zip(a, a)
-    @test collect(zd) == collect(za)
-    @test all(zd .== za)
-    a = collect(da)
+    a = rand(10, 9, 2)
+    b = rand(10, 9, 2)
+    da = _DiskArray(a; chunksize=(5, 3, 2));
+    db = _DiskArray(b; chunksize=(5, 3, 2));
+    z = zip(a, b)
+    zd = zip(da, db)
+    zdc = collect(zd) 
+    zc = collect(z)
+    @test da.getindex_count[] == 6
+    @test db.getindex_count[] == 6
+    @test all(zd .== z)
+    @test all(zdc .== zc)
     @test zip(a, da, a) isa DiskArrays.DiskZip
     @test zip(da, da, a) isa DiskArrays.DiskZip
     @test zip(da, da, da) isa DiskArrays.DiskZip


### PR DESCRIPTION
This PR fixes `zip` by adding a `RechunkedDiskArray` that we can use to force a specific access pattern on a `AbstracDiskArray` or a regular `AbstractArray`.

In `zip` we then force all the arrays to have the same pattern as the first disk array we find that is `Chunked`.

This will be a bit slower when the chunks don't match, but at least it is correct. We could later calculate some optimal chunk pattern for all arrays passed to `zip` given the available memory.

This fixes some outstanding `@test_broken` tests, because `==` uses zip underneath.

Closes #103