### PR TITLE
fix generators

### DIFF
--- a/src/DiskArrays.jl
+++ b/src/DiskArrays.jl
@@ -19,6 +19,7 @@ include("permute.jl")
 include("reshape.jl")
 include("subarray.jl")
 include("cat.jl")
+include("generator.jl")
 
 # The all-in-one macro
 
@@ -36,6 +37,7 @@ macro implement_diskarray(t)
         @implement_subarray $t
         @implement_batchgetindex $t
         @implement_cat $t
+        @implement_generator $t
     end
 end
 

--- a/src/generator.jl
+++ b/src/generator.jl
@@ -1,0 +1,48 @@
+
+struct DiskGenerator{I,F}
+    f::F
+    iter::I
+end
+# Copied from `iterate(::Generator, s...) in julia 1.9
+function Base.iterate(dg::DiskGenerator, s...)
+    @inline 
+    y = iterate(dg.iter, s...)
+    y === nothing && return nothing
+    y = y::Tuple{Any, Any} # try to give inference some idea of what to expect about the behavior of the next line
+    return (dg.f(y[1]), y[2])
+end
+Base.isempty(dg::DiskGenerator) = Base.isempty(dg.iter)
+Base.length(dg::DiskGenerator) = Base.length(dg.iter)
+Base.ndims(dg::DiskGenerator) = Base.ndims(dg.iter)
+Base.size(dg::DiskGenerator) = Base.size(dg.iter)
+Base.keys(dg::DiskGenerator) = Base.keys(dg.iter)
+Base.IteratorSize(::Type{DiskGenerator{I,F}}) where {I,F} =
+    Base.IteratorSize(Iterators.Generator{I,F})
+Base.IteratorEltype(::Type{DiskGenerator{I,F}}) where {I,F} =
+    Base.IteratorEltype(Iterators.Generator{I,F})
+
+# Collect zipped disk arrays in the right order
+# Copied from `collect(::Generator) in julia 1.9
+function Base.collect(itr::DiskGenerator{<:AbstractArray{<:Any,N}}) where N
+    et = Base.@default_eltype(itr)
+    y = iterate(itr)
+    shp = axes(itr.iter)
+    if y === nothing
+        return similar(Array{et,N}, shp)
+    end
+    v1, st = y
+    dest = similar(Array{typeof(v1),N}, shp)
+    i = iterate(itr)
+    for I in eachindex(itr.iter)
+        dest[I] = first(i)
+        i = iterate(itr, last(i))
+    end
+    return dest
+end
+
+macro implement_generator(t)
+    t = esc(t)
+    quote
+        Base.Generator(f, A::$t) = $DiskGenerator(f, A)
+    end
+end

--- a/src/generator.jl
+++ b/src/generator.jl
@@ -5,7 +5,6 @@ struct DiskGenerator{I,F}
 end
 # Copied from `iterate(::Generator, s...) in julia 1.9
 function Base.iterate(dg::DiskGenerator, s...)
-    @inline 
     y = iterate(dg.iter, s...)
     y === nothing && return nothing
     y = y::Tuple{Any, Any} # try to give inference some idea of what to expect about the behavior of the next line

--- a/src/generator.jl
+++ b/src/generator.jl
@@ -23,15 +23,16 @@ Base.IteratorEltype(::Type{DiskGenerator{I,F}}) where {I,F} =
 # Collect zipped disk arrays in the right order
 # Copied from `collect(::Generator) in julia 1.9
 function Base.collect(itr::DiskGenerator{<:AbstractArray{<:Any,N}}) where N
-    et = Base.@default_eltype(itr)
+    
     y = iterate(itr)
     shp = axes(itr.iter)
     if y === nothing
+        et = Base.@default_eltype(itr)
         return similar(Array{et,N}, shp)
     end
     v1, st = y
     dest = similar(Array{typeof(v1),N}, shp)
-    i = iterate(itr)
+    i = y
     for I in eachindex(itr.iter)
         dest[I] = first(i)
         i = iterate(itr, last(i))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -464,6 +464,15 @@ end
     @test getindex_count(a_disk) == 6
     # Filtered generators dont work yet
     @test_broken [aa for aa in a_disk if aa > 40] == [aa for aa in a if aa > 40] 
+    #Iterator interface tests
+    g = Base.Generator(identity,a_disk)
+    @test g isa DiskArrays.DiskGenerator
+    @test size(g) == (10,9)
+    @test !isempty(g)
+    @test length(g) == 90
+    @test ndims(g) == 2
+    @test keys(g) == CartesianIndices((10,9))
+
 end
 
 @testset "Array methods" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -460,6 +460,8 @@ end
     a = collect(reshape(1:90, 10, 9))
     a_disk = _DiskArray(a; chunksize=(5, 3))
     @test [aa for aa in a_disk] == a
+    # Filtered generators dont work yet
+    @test_broken [aa for aa in a_disk if aa > 40] == [aa for aa in a if aa > 40] 
 end
 
 @testset "Array methods" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -460,6 +460,8 @@ end
     a = collect(reshape(1:90, 10, 9))
     a_disk = _DiskArray(a; chunksize=(5, 3))
     @test [aa for aa in a_disk] == a
+    #The array has 6 chunks so getindex_count should be 6
+    @test getindex_count(a_disk) == 6
     # Filtered generators dont work yet
     @test_broken [aa for aa in a_disk if aa > 40] == [aa for aa in a if aa > 40] 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -456,6 +456,12 @@ end
     @test setindex_count(b) == 4
 end
 
+@testset "generator" begin
+    a = collect(reshape(1:90, 10, 9))
+    a_disk = _DiskArray(a; chunksize=(5, 3))
+    @test [aa for aa in a_disk] == a
+end
+
 @testset "Array methods" begin
     a = collect(reshape(1:90, 10, 9))
     a_disk = _DiskArray(a; chunksize=(5, 3))
@@ -463,7 +469,6 @@ end
     @test ei isa DiskArrays.BlockedIndices
     @test length(ei) == 90
     @test eltype(ei) == CartesianIndex{2}
-    @test_broken [aa for aa in a_disk] == a
     @test collect(a_disk) == a
     @test Array(a_disk) == a
     @testset "copyto" begin


### PR DESCRIPTION
This PR defines a `DiskGenerator` to reorder `collect` during iteration. This fixes one of the last broken tests.

Closes #106 

This wont work if a filter is used in the generator so adds another broken test. This would be very hard to do as we don't know the final size or indices at the start. Probably we should disallow it somehow.