### PR TITLE
fix CartesianIndices in batchgetindex

### DIFF
--- a/src/batchgetindex.jl
+++ b/src/batchgetindex.jl
@@ -63,12 +63,9 @@ function create_indexvector(a, i)
     end
 end
 
-function batchgetindex(a, i::AbstractVector{Int})
-    ci = CartesianIndices(size(a))
-    return batchgetindex(a, ci[i])
-end
 function batchgetindex(a, i...)
-    indvec = create_indexvector(a, i)
+    I = view(CartesianIndices(size(a)), i...)
+    indvec = create_indexvector(a, (I,))
     return disk_getindex_batch(a, indvec)
 end
 

--- a/src/diskarray.jl
+++ b/src/diskarray.jl
@@ -33,8 +33,10 @@ is_batch_arg(::AbstractRange) = false
 
 function getindex_disk(a, i...)
     checkscalar(i)
+    i = to_indices(a, i)
     if any(is_batch_arg, i)
-        batchgetindex(a, i...) else
+        batchgetindex(a, i...) 
+    else
         inds, trans = interpret_indices_disk(a, i)
         data = Array{eltype(a)}(undef, map(length, inds)...)
         readblock!(a, data, inds...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -346,6 +346,16 @@ end
     test_broadcast(a_disk1)
 end
 
+@testset "CartesianIndices in vectors" begin
+    a = rand(10, 12, 15)
+    da = _DiskArray(a; chunksize=(5, 10, 2))
+    r = [1 4 6 1]
+    c = [7 8 9 3]
+    cartind = CartesianIndex.(r, c)
+    @test a[cartind, :] == da[cartind, :]
+    @test a[:, cartind] == da[:, cartind]
+end
+
 @testset "cat" begin
     da = _DiskArray(collect(reshape(1:24, 4, 6, 1)))
     a = view(da, :, 1:3, :) 


### PR DESCRIPTION
This PR uses the strategy previously on `Vector{Int}` for all indexing to avoid bugs like #84. It uses `view` instead of `getindex` to avoid large allocations.

Fixes #84