### PR TITLE
Macro main

### DIFF
--- a/src/zip.jl
+++ b/src/zip.jl
@@ -74,6 +74,6 @@ macro implement_zip(t)
 
         Base.zip(::$t, x, xs...) = $_zip_error()
         Base.zip(x, ::$t, xs...) = $_zip_error()
-        Base.zip($t, ::$t, xs...) = $_zip_error()
+        Base.zip(::$t, ::$t, xs...) = $_zip_error()
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,7 +40,7 @@ end
 _DiskArray(a; chunksize=size(a)) = _DiskArray(Ref(0), Ref(0), a, chunksize)
 
 # Apply the all in one macro rather than inheriting
-DiskArrays.@implement_diskarray _DiskArray
+DiskArrays.@implement_diskarray Main._DiskArray
 
 Base.size(a::_DiskArray) = size(a.parent)
 DiskArrays.haschunks(::_DiskArray) = DiskArrays.Chunked()


### PR DESCRIPTION
This PR uses `Main._DiskArray` in tests to better catch errors in macro use.