### PR TITLE
fix 1.10 Vararg deprecation warning

### DIFF
--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -109,7 +109,7 @@ end
 grid_offset(r::IrregularChunks) = 0
 max_chunksize(r::IrregularChunks) = maximum(diff(r.offsets))
 
-struct GridChunks{N,C<:Tuple{Vararg{<:ChunkType,N}}} <: AbstractArray{NTuple{N,UnitRange{Int64}},N}
+struct GridChunks{N,C<:Tuple{Vararg{ChunkType,N}}} <: AbstractArray{NTuple{N,UnitRange{Int64}},N}
     chunks::C
 end
 GridChunks(ct::ChunkType...) = GridChunks(ct)


### PR DESCRIPTION
Saw this running ArchGDAL tests:

```
Precompiling project...
  2 dependencies successfully precompiled in 7 seconds. 87 already precompiled.
  1 dependency had warnings during precompilation:
┌ DiskArrays [3c3547ce-8d99-4f5e-a174-61eb10b00ae3]
│  WARNING: Wrapping `Vararg` directly in UnionAll is deprecated (wrap the tuple instead).
│  You may need to write `f(x::Vararg{T})` rather than `f(x::Vararg{<:T})` or `f(x::Vararg{T}) where T` instead of `f(x::Vararg{T} where T)`.
│  WARNING: Wrapping `Vararg` directly in UnionAll is deprecated (wrap the tuple instead).
│  You may need to write `f(x::Vararg{T})` rather than `f(x::Vararg{<:T})` or `f(x::Vararg{T}) where T` instead of `f(x::Vararg{T} where T)`.
│  WARNING: Wrapping `Vararg` directly in UnionAll is deprecated (wrap the tuple instead).
│  You may need to write `f(x::Vararg{T})` rather than `f(x::Vararg{<:T})` or `f(x::Vararg{T}) where T` instead of `f(x::Vararg{T} where T)`.
└
```

This should still behave the same:
```
julia> g(x::Vararg{Real}) = 1
g (generic function with 1 method)

julia> g(1.0)
1

julia> g("")
ERROR: MethodError: no method matching g(::String)

Closest candidates are:
  g(::Real...)
   @ Main REPL[11]:1
```