### PR TITLE
Validate chunktypes

### DIFF
--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -24,6 +24,8 @@ struct RegularChunks <: ChunkType
     s::Int
     function RegularChunks(cs::Int,offset::Int,s::Int)
         cs>0 || throw(ArgumentError("Chunk sizes must be strictly positive"))
+        -1 < offset < cs || throw(ArgumentError("Offsets must be positive and smaller than the chunk size"))
+        s >= 0 || throw(ArgumentError("Negative dimension lengths are not allowed"))
         new(cs,offset,s)
     end
 end

--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -22,6 +22,10 @@ struct RegularChunks <: ChunkType
     cs::Int
     offset::Int
     s::Int
+    function RegularChunks(cs::Int,offset::Int,s::Int)
+        cs>0 || throw(ArgumentError("Chunk sizes must be strictly positive"))
+        new(cs,offset,s)
+    end
 end
 
 # Base methods
@@ -76,6 +80,11 @@ Defines chunks along a dimension where chunk sizes are not constant but arbitrar
 """
 struct IrregularChunks <: ChunkType
     offsets::Vector{Int}
+    function IrregularChunks(offsets::Vector{Int})
+        first(offsets)==0 || throw(ArgumentError("First Offset of an Irregularchunk must be 0"))
+        all(i->offsets[i]<offsets[i+1],1:(length(offsets)-1)) || throw(ArgumentError("Offsets of an Irregularchunk must be strictly ordered"))
+        new(offsets)
+    end
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -246,6 +246,7 @@ end
     @test size(a2) == (10,)
     @test_throws BoundsError a2[0]
     @test_throws BoundsError a2[11]
+    @test_throws ArgumentError RegularChunks(0,2,10)
     b1 = IrregularChunks(; chunksizes=[3, 3, 4, 3, 3])
     @test b1[1] == 1:3
     @test b1[2] == 4:6
@@ -267,6 +268,8 @@ end
     @test DiskArrays.approx_chunksize(gridc) == (5, 2, 3)
     @test DiskArrays.grid_offset(gridc) == (2, 0, 0)
     @test DiskArrays.max_chunksize(gridc) == (5, 2, 4)
+    @test_throws ArgumentError IrregularChunks([1,2,3])
+    @test_throws ArgumentError IrregularChunks([0,5,4])
 end
 
 @testset "SubsetChunks" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -247,6 +247,9 @@ end
     @test_throws BoundsError a2[0]
     @test_throws BoundsError a2[11]
     @test_throws ArgumentError RegularChunks(0,2,10)
+    @test_throws ArgumentError RegularChunks(2,-1,10)
+    @test_throws ArgumentError RegularChunks(2,2,10)
+    @test_throws ArgumentError RegularChunks(5,2,-1)
     b1 = IrregularChunks(; chunksizes=[3, 3, 4, 3, 3])
     @test b1[1] == 1:3
     @test b1[2] == 4:6


### PR DESCRIPTION
This adds a few safety brakes when constructing objects of type `RegularChunks` and `IrregularChunks` to avoid harder to debug errors later.  