### PR TITLE
allow all Integer types in RegularChunks

### DIFF
--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -22,11 +22,11 @@ struct RegularChunks <: ChunkType
     cs::Int
     offset::Int
     s::Int
-    function RegularChunks(cs::Int,offset::Int,s::Int)
+    function RegularChunks(cs::Integer, offset::Integer, s::Integer)
         cs>0 || throw(ArgumentError("Chunk sizes must be strictly positive"))
         -1 < offset < cs || throw(ArgumentError("Offsets must be positive and smaller than the chunk size"))
         s >= 0 || throw(ArgumentError("Negative dimension lengths are not allowed"))
-        new(cs,offset,s)
+        new(Int(cs), Int(offset), Int(s))
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -273,6 +273,8 @@ end
     @test DiskArrays.max_chunksize(gridc) == (5, 2, 4)
     @test_throws ArgumentError IrregularChunks([1,2,3])
     @test_throws ArgumentError IrregularChunks([0,5,4])
+    # Make sure mixed Integer types work
+    @test RegularChunks(Int32(5), 2, UInt32(10)) == RegularChunks(5, 2, 10)
 end
 
 @testset "SubsetChunks" begin


### PR DESCRIPTION
ArchGDAL is broken on master because it passes Int32 to GridChunks