### PR TITLE
Dispatch on the dims type in cat_disk to allow for one element tuples for dims in cat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,10 @@ version = "0.3.22"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 
 [compat]
+Aqua = "0.8"
 OffsetArrays = "1"
+Statistics = "1.6"
+Test = "1.6"
 julia = "1.6"
 
 [extras]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,7 +16,6 @@ if VERSION >= v"1.9.0"
     Aqua.test_undefined_exports(DiskArrays)
     Aqua.test_project_extras(DiskArrays)
     Aqua.test_deps_compat(DiskArrays)
-    Aqua.test_project_toml_formatting(DiskArrays)
 end
 
 @testset "allow_scalar" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -420,6 +420,20 @@ end
         @test collect(cat(collect(a), b; dims=1)) == cat(collect(a), collect(b); dims=1)
     end
 
+    @testset "cat with 1-Tuple dimension" begin
+        @test cat(a, b; dims=(1,)) isa DiskArrays.ConcatDiskArray
+        @test cat(a, b; dims=(1,)) == cat(a, b; dims=1)
+        @test collect(cat(a, b; dims=(1,))) == cat(collect(a), collect(b); dims=(1,))
+        @test collect(cat(a, b; dims=(2,))) == cat(collect(a), collect(b); dims=(2,))
+        @test collect(cat(a, b; dims=(3,))) == cat(collect(a), collect(b); dims=(3,))
+        @test collect(cat(a, b; dims=(4,))) == cat(collect(a), collect(b); dims=(4,))
+        @test collect(cat(a, b; dims=(5,))) == cat(collect(a), collect(b); dims=(5,))
+    end 
+
+    @testset "cat with 2-tuple" begin
+        @test_throws ArgumentError cat(a,b, dims=(1,2))
+    end
+
     @testset "write concat" begin
         ca .= reshape(0:23, 4, 6)
         @test sum(ca) == sum(0:23)


### PR DESCRIPTION
This would partially fix #133 by handling the case when the iterator has only one element and that needs to put out of the tuple and forward to the original method. This makes it possible to use cat from DimensionalData with DiskArray backed arrays.

I had to rearrange the cat_disk function so that we can dispatch on the dims type. 

The entries in the Project.toml are because Aqua was complaining. 

