### PR TITLE
Enable broadcasted assignment with trailing singleton dimensions

### DIFF
--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -123,6 +123,8 @@ function maybeonerange(out, sizes, ranges)
     return maybeonerange((out..., repsingle(s1, r1)), sr, rr)
 end
 maybeonerange(out, ::Tuple{}, ranges) = out
+maybeonerange(out, sizes, ::Tuple{}) = out
+maybeonerange(out, ::Tuple{}, ::Tuple{}) = out
 maybeonerange(sizes, ranges) = maybeonerange((), sizes, ranges)
 splittuple(x1, xr...) = x1, xr
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -476,6 +476,14 @@ end
     @test r[] == 0
 end
 
+@testset "Broadcasted assignment with trailing singleton dimensions" begin
+    a1 = rand(10,9,1,1)
+    a_disk1 = _DiskArray(a1)
+    s = zeros(10,9)
+    s .= a_disk1
+    @test s == a1[:,:,1,1]
+end
+
 @testset "Getindex/Setindex with vectors" begin
     a = _DiskArray(reshape(1:20, 4, 5, 1); chunksize=(4, 1, 1))
     @test a[:, [1, 4], 1] == trueparent(a)[:, [1, 4], 1]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -476,12 +476,16 @@ end
     @test r[] == 0
 end
 
-@testset "Broadcasted assignment with trailing singleton dimensions" begin
-    a1 = rand(10,9,1,1)
-    a_disk1 = _DiskArray(a1)
-    s = zeros(10,9)
-    s .= a_disk1
-    @test s == a1[:,:,1,1]
+if VERSION >= v"1.7.0"
+    @testset "Broadcasted assignment with trailing singleton dimensions" begin
+        a1 = rand(10,9,1,1)
+        a_disk1 = _DiskArray(a1)
+        s = zeros(10,9)
+        @test begin
+            s .= a_disk1
+            s == a1[:,:,1,1]
+        end
+    end
 end
 
 @testset "Getindex/Setindex with vectors" begin


### PR DESCRIPTION
With regular `Array`s, it is possible to do a broadcasted assignment to a destination with fewer dimensions when the trailing dimensions all have size 1:

```julia
dest = zeros(10,9)
src = rand(10,9,1,1)
dest .= src

@assert dest == src[:,:,1,1]
```

But if `src` is a `DiskArray`, this fails:

```julia
using DiskArrays

struct _DiskArray{T,N,A<:AbstractArray{T,N}} <: AbstractArray{T,N}
    parent::A
    chunksize::NTuple{N,Int}
end
_DiskArray(a; chunksize=size(a)) = _DiskArray(a, chunksize)
DiskArrays.@implement_diskarray _DiskArray
Base.size(a::_DiskArray) = size(a.parent)
DiskArrays.haschunks(::_DiskArray) = DiskArrays.Chunked()
DiskArrays.eachchunk(a::_DiskArray) = DiskArrays.GridChunks(a, a.chunksize)
DiskArrays.readblock!(a::_DiskArray, aout, i::AbstractUnitRange...) = aout .= a.parent[i...]
DiskArrays.writeblock!(a::_DiskArray, v, i::AbstractUnitRange...) = view(a.parent, i...) .= v

data = rand(10,9,1,1)
src = _DiskArray(data)
dest = zeros(10,9)
dest .= src

@assert dest == data[:,:,1,1]
```

with the error:

```julia
ERROR: MethodError: no method matching splittuple()

Closest candidates are:
  splittuple(::Any, ::Any...)
   @ DiskArrays ~/.julia/packages/DiskArrays/1rcQi/src/broadcast.jl:127

Stacktrace:
  [1] maybeonerange(out::Tuple{UnitRange{Int64}, UnitRange{Int64}}, sizes::Tuple{Int64, Int64}, ranges::Tuple{})
    @ DiskArrays ~/.julia/packages/DiskArrays/1rcQi/src/broadcast.jl:122
  [2] maybeonerange(out::Tuple{UnitRange{Int64}}, sizes::Tuple{Int64, Int64, Int64}, ranges::Tuple{UnitRange{Int64}})
    @ DiskArrays ~/.julia/packages/DiskArrays/1rcQi/src/broadcast.jl:123
  [3] maybeonerange(out::Tuple{}, sizes::NTuple{4, Int64}, ranges::Tuple{UnitRange{Int64}, UnitRange{Int64}})
    @ DiskArrays ~/.julia/packages/DiskArrays/1rcQi/src/broadcast.jl:123
  [4] maybeonerange(sizes::NTuple{4, Int64}, ranges::Tuple{UnitRange{Int64}, UnitRange{Int64}})
    @ DiskArrays ~/.julia/packages/DiskArrays/1rcQi/src/broadcast.jl:126
  [5] subsetarg(x::_DiskArray{Float64, 4, Array{Float64, 4}}, a::Tuple{UnitRange{Int64}, UnitRange{Int64}})
    @ Main ~/.julia/packages/DiskArrays/1rcQi/src/broadcast.jl:144
  [6] (::DiskArrays.var"#62#64"{Tuple{UnitRange{Int64}, UnitRange{Int64}}})(i::_DiskArray{Float64, 4, Array{Float64, 4}})
    @ DiskArrays ~/.julia/packages/DiskArrays/1rcQi/src/broadcast.jl:41
  [7] map
    @ ./tuple.jl:291 [inlined]
  [8] (::DiskArrays.var"#61#63"{Matrix{…}, Base.Broadcast.Broadcasted{…}})(cnow::Tuple{UnitRange{…}, UnitRange{…}})
    @ DiskArrays ~/.julia/packages/DiskArrays/1rcQi/src/broadcast.jl:41
  [9] foreach(f::DiskArrays.var"#61#63"{Matrix{…}, Base.Broadcast.Broadcasted{…}}, itr::DiskArrays.GridChunks{2, Tuple{…}})
    @ Base ./abstractarray.jl:3094
 [10] copyto!(dest::Matrix{…}, bc::Base.Broadcast.Broadcasted{…})
    @ DiskArrays ~/.julia/packages/DiskArrays/1rcQi/src/broadcast.jl:38
 [11] materialize!
    @ Base.Broadcast ./broadcast.jl:914 [inlined]
 [12] materialize!(dest::Matrix{…}, bc::Base.Broadcast.Broadcasted{…})
    @ Base.Broadcast ./broadcast.jl:911
 [13] top-level scope
    @ REPL[16]:1
```

This seems to occur in the case where there are trailing singleton dimensions because the recursive ` maybeonerange` does not reach the correct base case. This can be fixed by adding the following cases

```julia
maybeonerange(out, sizes, ::Tuple{}) = out
maybeonerange(out, ::Tuple{}, ::Tuple{}) = out
```
where the first one is the case that we reach with the trailing singleton dimensions. The second one is needed to resolve method ambiguities. I think by the time the call gets to this point, the array shapes have all been checked, so it should be safe to do this, but I could be wrong.

This pull request makes that change and adds a test.



