### PR TITLE
use summary and eachchunk in show

### DIFF
--- a/src/DiskArrays.jl
+++ b/src/DiskArrays.jl
@@ -22,6 +22,7 @@ include("rechunk.jl")
 include("cat.jl")
 include("generator.jl")
 include("zip.jl")
+include("show.jl")
 
 # The all-in-one macro
 
@@ -41,6 +42,7 @@ macro implement_diskarray(t)
         @implement_batchgetindex $t
         @implement_cat $t
         @implement_zip $t
+        @implement_show $t
         @implement_generator $t
     end
 end
@@ -58,5 +60,6 @@ end
 @implement_batchgetindex AbstractDiskArray
 @implement_cat AbstractDiskArray
 @implement_generator AbstractDiskArray
+@implement_show AbstractDiskArray
 
 end # module

--- a/src/diskarray.jl
+++ b/src/diskarray.jl
@@ -240,10 +240,3 @@ macro implement_setindex(t)
         end
     end
 end
-
-function Base.show(io::IO, ::MIME"text/plain", X::AbstractDiskArray)
-    return println(io, "Disk Array with size ", join(size(X), " x "))
-end
-function Base.show(io::IO, X::AbstractDiskArray)
-    return println(io, "Disk Array with size ", join(size(X), " x "))
-end

--- a/src/show.jl
+++ b/src/show.jl
@@ -1,0 +1,20 @@
+
+macro implement_show(t)
+    t = esc(t)
+    quote
+        Base.show(io::IO, mime::MIME"text/plain", A::$t) = _show(io, mime, A)
+        Base.show(io::IO, A::$t) = _show(io, A) 
+    end
+end
+
+_show(io, A) = summary(io, A)
+function _show(io, mime, A)
+    summary(io, A)
+    println(io)
+    println(io)
+    print(io, nameof(typeof(haschunks(A))))
+    if haschunks(A) isa Chunked
+        print(io, ": ")
+        show(io, mime, eachchunk(A))
+    end
+end


### PR DESCRIPTION
This PR adds a `@implement_show` macro so show can be applied to non-`AbstractDiskArray`, and shows the type `summary` and chunk type from `haschunks`.

For `Chunked` it also shows the chunk pattern - I'm not sure we need this bit but its helpful sometimes.

It looks like this:
```julia
julia> a = AccessCountDiskArray(data; chunksize=(5, 4, 2))
10×20×2 AccessCountDiskArray{Float64, 3, Array{Float64, 3}}

Chunked: 2×5×1 DiskArrays.GridChunks{3, Tuple{DiskArrays.RegularChunks, DiskArrays.RegularChunks, DiskArrays.RegularChunks}}:
[:, :, 1] =
 (1:5, 1:4, 1:2)   (1:5, 5:8, 1:2)   (1:5, 9:12, 1:2)   (1:5, 13:16, 1:2)   (1:5, 17:20, 1:2)
 (6:10, 1:4, 1:2)  (6:10, 5:8, 1:2)  (6:10, 9:12, 1:2)  (6:10, 13:16, 1:2)  (6:10, 17:20, 1:2)
```