### PR TITLE
Remove unnecessary use of `length(::Stateful)`

### DIFF
--- a/src/iterator.jl
+++ b/src/iterator.jl
@@ -26,7 +26,7 @@ function Base.iterate(::BlockedIndices, i)
     if r === nothing
         ii = iterate(chunkiter)
         ii === nothing && return nothing
-        innerinds = Iterators.Stateful(CartesianIndices(first(ii)))
+        Iterators.reset!(innerinds, CartesianIndices(first(ii)))
         r = iterate(innerinds)
         r === nothing && return nothing
         return first(r), (chunkiter, innerinds)

--- a/src/iterator.jl
+++ b/src/iterator.jl
@@ -42,7 +42,7 @@ end
 ) where {T,I<:Tuple{A,B,C}} where {A,B,C}
     datacur::A, bi::B, bstate::C = i
     (chunkiter, innerinds) = bstate
-    cistateold = isdone(innerinds)
+    cistateold = isempty(innerinds)
     biter = iterate(bi, bstate)
     if biter === nothing
         return nothing

--- a/src/iterator.jl
+++ b/src/iterator.jl
@@ -42,14 +42,14 @@ end
 ) where {T,I<:Tuple{A,B,C}} where {A,B,C}
     datacur::A, bi::B, bstate::C = i
     (chunkiter, innerinds) = bstate
-    cistateold = length(chunkiter)
+    cistateold = isdone(innerinds)
     biter = iterate(bi, bstate)
     if biter === nothing
         return nothing
     else
         innernow, bstatenew = biter
         (chunkiter, innerinds) = bstatenew
-        if length(chunkiter) !== cistateold
+        if cistateold
             curchunk = innerinds.itr.indices
             datacur = OffsetArray(a[curchunk...], innerinds.itr)
             return datacur[innernow]::T, (datacur, bi, bstatenew)::I


### PR DESCRIPTION
Editing only in Github editor, so CI needs to run on this, but I think this should be equivalent in the current implementation. If the shape of innerinds is consistent, this custom iterator code could also be replaced by an `Iterators.product(chunkiter, innerinds)` instance.