### PR TITLE
Delete zero element method  from writeblock! and readblock!

### DIFF
--- a/src/diskarray.jl
+++ b/src/diskarray.jl
@@ -12,7 +12,7 @@ abstract type AbstractDiskArray{T,N} <: AbstractArray{T,N} end
 
 The only function that should be implemented by a `AbstractDiskArray`. This function
 """
-function readblock!() end
+function readblock! end
 
 """
     writeblock!(A::AbstractDiskArray, A_in, r::AbstractUnitRange...)
@@ -20,7 +20,7 @@ function readblock!() end
 Function that should be implemented by a `AbstractDiskArray` if write operations
 should be supported as well.
 """
-function writeblock!() end
+function writeblock! end
 
 
 function allow_multi_chunk_access(a)


### PR DESCRIPTION
I suspect that these are not needed and they should be generic function definitions to define the DiskArray interface.

Tests go through locally. 
