### PR TITLE
Fix a case of wrong aliasing for setindex

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiskArrays"
 uuid = "3c3547ce-8d99-4f5e-a174-61eb10b00ae3"
 authors = ["Fabian Gans <fgans@bgc-jena.mpg.de>"]
-version = "0.4.1"
+version = "0.4.2"
 
 [deps]
 LRUCache = "8ac3fa9e-de4c-5943-b1dc-09c6b5f20637"

--- a/src/diskarray.jl
+++ b/src/diskarray.jl
@@ -168,7 +168,7 @@ splitcs(::Tuple{}, csnow, csrem) = (csnow, csrem)
 function output_aliasing(di::DiskIndex, ndims_dest, ndims_source)
     if all(i->isa(i,Union{Int,AbstractUnitRange,Colon}),di.temparray_indices) && 
         all(i->isa(i,Union{Int,AbstractUnitRange,Colon}),di.output_indices)
-        if di.output_size == di.temparray_size && nda == ndv
+        if di.output_size == di.temparray_size && ndims_dest == ndims_source
             return :identical
         else 
             return :reshapeoutput

--- a/src/diskarray.jl
+++ b/src/diskarray.jl
@@ -165,7 +165,7 @@ splitcs(::Tuple{}, csnow, csrem) = (csnow, csrem)
 
 #Determine wether output and temp array can a) be identical b) share memory through reshape or 
 # c) need to be allocated individually
-function output_aliasing(di::DiskIndex,nda,ndv)
+function output_aliasing(di::DiskIndex, ndims_dest, ndims_source)
     if all(i->isa(i,Union{Int,AbstractUnitRange,Colon}),di.temparray_indices) && 
         all(i->isa(i,Union{Int,AbstractUnitRange,Colon}),di.output_indices)
         if di.output_size == di.temparray_size && nda == ndv

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -75,7 +75,7 @@ function test_setindex(a)
     a[1, 1, 1] = 1
     a[1, 2] = 2
     a[1, 3, 1, 1] = 3
-    a[2, :] = [1, 2, 3, 4, 5]
+    a[2:2, :] = [1, 2, 3, 4, 5]
     a[3, 3:4, 1, 1] = [3, 4]
     # Test bitmask indexing
     m = falses(4, 5, 1)
@@ -468,21 +468,20 @@ end
     a = AccessCountDiskArray(reshape(1:20, 4, 5, 1); chunksize=(4, 1, 1))
     i = (1:3,:,:)
     di = DiskArrays.resolve_indices(a,i,DiskArrays.NoBatch())
-    @test DiskArrays.output_aliasing(di) == :identical
+    @test DiskArrays.output_aliasing(di,3,3) == :identical
+    @test DiskArrays.output_aliasing(di,2,3) == :reshapeoutput
     i = (1,:,:)
     di = DiskArrays.resolve_indices(a,i,DiskArrays.NoBatch())
-    @test DiskArrays.output_aliasing(di) == :reshapeoutput
+    @test DiskArrays.output_aliasing(di,2,2) == :reshapeoutput
     i = ([1,3],:,:)
     di = DiskArrays.resolve_indices(a,i,DiskArrays.NoBatch())
-    @test DiskArrays.output_aliasing(di) == :noalign
+    @test DiskArrays.output_aliasing(di,3,3) == :noalign
     i = (1:3,:)
     di = DiskArrays.resolve_indices(a,i,DiskArrays.NoBatch())
-    @test DiskArrays.output_aliasing(di) == :reshapeoutput
+    @test DiskArrays.output_aliasing(di,2,2) == :reshapeoutput
     i = (1:3,:,:,1,1)
     di = DiskArrays.resolve_indices(a,i,DiskArrays.NoBatch())
-    @test DiskArrays.output_aliasing(di) == :identical
-
-
+    @test DiskArrays.output_aliasing(di,3,3) == :identical
 end
 
 


### PR DESCRIPTION
This occured in `setindex!` cases where source and destination shape were not the same, e.g.

````julia
a[1:10,2:2] = 1:10
````

A test was added for this in setindex tests.  