### PR TITLE
Shorten chunk output in show

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -15,6 +15,6 @@ function _show(io, mime, A)
     print(io, nameof(typeof(haschunks(A))))
     if haschunks(A) isa Chunked
         print(io, ": ")
-        show(io, mime, eachchunk(A))
+        show(io, mime, (map(c->length.(c),eachchunk(A).chunks)))
     end
 end

--- a/src/show.jl
+++ b/src/show.jl
@@ -8,13 +8,18 @@ macro implement_show(t)
 end
 
 _show(io, A) = summary(io, A)
-function _show(io, mime, A)
+function _show(io, _, A)
     summary(io, A)
     println(io)
     println(io)
     print(io, nameof(typeof(haschunks(A))))
     if haschunks(A) isa Chunked
-        print(io, ": ")
-        show(io, mime, (map(c->length.(c),eachchunk(A).chunks)))
+        print(io, ": (\n")
+        foreach(eachchunk(A).chunks) do c
+            print(io,"    ")
+            show(IOContext(io,:compact => true), length.(c))
+            print(io,"\n")
+        end
+        println(io,")")
     end
 end


### PR DESCRIPTION
With the old `show` function outer product of all chunksizes is printed to the screen which is quite excessive. This condenses the output a bit. @rafaqz is this ok for you?

new

````
1440×720×1840 XRDataArrayDiskArray{Float32, 3}

Chunked: ([90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90], [90, 90, 90, 90, 90, 90, 90, 90], [184, 184, 184, 184, 184, 184, 184, 184, 184, 184])
````

old:

````julia
1440×720×1840 XRDataArrayDiskArray{Float32, 3}

Chunked: 16×8×10 DiskArrays.GridChunks{3, Tuple{DiskArrays.RegularChunks, DiskArrays.RegularChunks, DiskArrays.RegularChunks}}:
[:, :, 1] =
 (1:90, 1:90, 1:184)       (1:90, 91:180, 1:184)       …  (1:90, 631:720, 1:184)
 (91:180, 1:90, 1:184)     (91:180, 91:180, 1:184)        (91:180, 631:720, 1:184)
 (181:270, 1:90, 1:184)    (181:270, 91:180, 1:184)       (181:270, 631:720, 1:184)
 (271:360, 1:90, 1:184)    (271:360, 91:180, 1:184)       (271:360, 631:720, 1:184)
 (361:450, 1:90, 1:184)    (361:450, 91:180, 1:184)       (361:450, 631:720, 1:184)
 (451:540, 1:90, 1:184)    (451:540, 91:180, 1:184)    …  (451:540, 631:720, 1:184)
 ⋮                                                     ⋱  
 (901:990, 1:90, 1:184)    (901:990, 91:180, 1:184)    …  (901:990, 631:720, 1:184)
 (991:1080, 1:90, 1:184)   (991:1080, 91:180, 1:184)      (991:1080, 631:720, 1:184)
 (1081:1170, 1:90, 1:184)  (1081:1170, 91:180, 1:184)     (1081:1170, 631:720, 1:184)
 (1171:1260, 1:90, 1:184)  (1171:1260, 91:180, 1:184)     (1171:1260, 631:720, 1:184)
 (1261:1350, 1:90, 1:184)  (1261:1350, 91:180, 1:184)     (1261:1350, 631:720, 1:184)
 (1351:1440, 1:90, 1:184)  (1351:1440, 91:180, 1:184)  …  (1351:1440, 631:720, 1:184)

[:, :, 2] =
 (1:90, 1:90, 185:368)       (1:90, 91:180, 185:368)       …  (1:90, 631:720, 185:368)
 (91:180, 1:90, 185:368)     (91:180, 91:180, 185:368)        (91:180, 631:720, 185:368)
 (181:270, 1:90, 185:368)    (181:270, 91:180, 185:368)       (181:270, 631:720, 185:368)
 (271:360, 1:90, 185:368)    (271:360, 91:180, 185:368)       (271:360, 631:720, 185:368)
 (361:450, 1:90, 185:368)    (361:450, 91:180, 185:368)       (361:450, 631:720, 185:368)
 (451:540, 1:90, 185:368)    (451:540, 91:180, 185:368)    …  (451:540, 631:720, 185:368)
 ⋮                                                         ⋱  
 (901:990, 1:90, 185:368)    (901:990, 91:180, 185:368)    …  (901:990, 631:720, 185:368)
 (991:1080, 1:90, 185:368)   (991:1080, 91:180, 185:368)      (991:1080, 631:720, 185:368)
 (1081:1170, 1:90, 185:368)  (1081:1170, 91:180, 185:368)     (1081:1170, 631:720, 185:368)
 (1171:1260, 1:90, 185:368)  (1171:1260, 91:180, 185:368)     (1171:1260, 631:720, 185:368)
 (1261:1350, 1:90, 185:368)  (1261:1350, 91:180, 185:368)     (1261:1350, 631:720, 185:368)
 (1351:1440, 1:90, 185:368)  (1351:1440, 91:180, 185:368)  …  (1351:1440, 631:720, 185:368)

[:, :, 3] =
 (1:90, 1:90, 369:552)       (1:90, 91:180, 369:552)       …  (1:90, 631:720, 369:552)
 (91:180, 1:90, 369:552)     (91:180, 91:180, 369:552)        (91:180, 631:720, 369:552)
 (181:270, 1:90, 369:552)    (181:270, 91:180, 369:552)       (181:270, 631:720, 369:552)
 (271:360, 1:90, 369:552)    (271:360, 91:180, 369:552)       (271:360, 631:720, 369:552)
 (361:450, 1:90, 369:552)    (361:450, 91:180, 369:552)       (361:450, 631:720, 369:552)
 (451:540, 1:90, 369:552)    (451:540, 91:180, 369:552)    …  (451:540, 631:720, 369:552)
 ⋮                                                         ⋱  
 (901:990, 1:90, 369:552)    (901:990, 91:180, 369:552)    …  (901:990, 631:720, 369:552)
 (991:1080, 1:90, 369:552)   (991:1080, 91:180, 369:552)      (991:1080, 631:720, 369:552)
 (1081:1170, 1:90, 369:552)  (1081:1170, 91:180, 369:552)     (1081:1170, 631:720, 369:552)
 (1171:1260, 1:90, 369:552)  (1171:1260, 91:180, 369:552)     (1171:1260, 631:720, 369:552)
 (1261:1350, 1:90, 369:552)  (1261:1350, 91:180, 369:552)     (1261:1350, 631:720, 369:552)
 (1351:1440, 1:90, 369:552)  (1351:1440, 91:180, 369:552)  …  (1351:1440, 631:720, 369:552)

[:, :, 4] =
 (1:90, 1:90, 553:736)       (1:90, 91:180, 553:736)       …  (1:90, 631:720, 553:736)
 (91:180, 1:90, 553:736)     (91:180, 91:180, 553:736)        (91:180, 631:720, 553:736)
 (181:270, 1:90, 553:736)    (181:270, 91:180, 553:736)       (181:270, 631:720, 553:736)
 (271:360, 1:90, 553:736)    (271:360, 91:180, 553:736)       (271:360, 631:720, 553:736)
 (361:450, 1:90, 553:736)    (361:450, 91:180, 553:736)       (361:450, 631:720, 553:736)
 (451:540, 1:90, 553:736)    (451:540, 91:180, 553:736)    …  (451:540, 631:720, 553:736)
 ⋮                                                         ⋱  
 (901:990, 1:90, 553:736)    (901:990, 91:180, 553:736)    …  (901:990, 631:720, 553:736)
 (991:1080, 1:90, 553:736)   (991:1080, 91:180, 553:736)      (991:1080, 631:720, 553:736)
 (1081:1170, 1:90, 553:736)  (1081:1170, 91:180, 553:736)     (1081:1170, 631:720, 553:736)
 (1171:1260, 1:90, 553:736)  (1171:1260, 91:180, 553:736)     (1171:1260, 631:720, 553:736)
 (1261:1350, 1:90, 553:736)  (1261:1350, 91:180, 553:736)     (1261:1350, 631:720, 553:736)
 (1351:1440, 1:90, 553:736)  (1351:1440, 91:180, 553:736)  …  (1351:1440, 631:720, 553:736)

[:, :, 5] =
 (1:90, 1:90, 737:920)       (1:90, 91:180, 737:920)       …  (1:90, 631:720, 737:920)
 (91:180, 1:90, 737:920)     (91:180, 91:180, 737:920)        (91:180, 631:720, 737:920)
 (181:270, 1:90, 737:920)    (181:270, 91:180, 737:920)       (181:270, 631:720, 737:920)
 (271:360, 1:90, 737:920)    (271:360, 91:180, 737:920)       (271:360, 631:720, 737:920)
 (361:450, 1:90, 737:920)    (361:450, 91:180, 737:920)       (361:450, 631:720, 737:920)
 (451:540, 1:90, 737:920)    (451:540, 91:180, 737:920)    …  (451:540, 631:720, 737:920)
 ⋮                                                         ⋱  
 (901:990, 1:90, 737:920)    (901:990, 91:180, 737:920)    …  (901:990, 631:720, 737:920)
 (991:1080, 1:90, 737:920)   (991:1080, 91:180, 737:920)      (991:1080, 631:720, 737:920)
 (1081:1170, 1:90, 737:920)  (1081:1170, 91:180, 737:920)     (1081:1170, 631:720, 737:920)
 (1171:1260, 1:90, 737:920)  (1171:1260, 91:180, 737:920)     (1171:1260, 631:720, 737:920)
 (1261:1350, 1:90, 737:920)  (1261:1350, 91:180, 737:920)     (1261:1350, 631:720, 737:920)
 (1351:1440, 1:90, 737:920)  (1351:1440, 91:180, 737:920)  …  (1351:1440, 631:720, 737:920)

[:, :, 6] =
 (1:90, 1:90, 921:1104)       (1:90, 91:180, 921:1104)       …  (1:90, 631:720, 921:1104)
 (91:180, 1:90, 921:1104)     (91:180, 91:180, 921:1104)        (91:180, 631:720, 921:1104)
 (181:270, 1:90, 921:1104)    (181:270, 91:180, 921:1104)       (181:270, 631:720, 921:1104)
 (271:360, 1:90, 921:1104)    (271:360, 91:180, 921:1104)       (271:360, 631:720, 921:1104)
 (361:450, 1:90, 921:1104)    (361:450, 91:180, 921:1104)       (361:450, 631:720, 921:1104)
 (451:540, 1:90, 921:1104)    (451:540, 91:180, 921:1104)    …  (451:540, 631:720, 921:1104)
 ⋮                                                           ⋱  
 (901:990, 1:90, 921:1104)    (901:990, 91:180, 921:1104)    …  (901:990, 631:720, 921:1104)
 (991:1080, 1:90, 921:1104)   (991:1080, 91:180, 921:1104)      (991:1080, 631:720, 921:1104)
 (1081:1170, 1:90, 921:1104)  (1081:1170, 91:180, 921:1104)     (1081:1170, 631:720, 921:1104)
 (1171:1260, 1:90, 921:1104)  (1171:1260, 91:180, 921:1104)     (1171:1260, 631:720, 921:1104)
 (1261:1350, 1:90, 921:1104)  (1261:1350, 91:180, 921:1104)     (1261:1350, 631:720, 921:1104)
 (1351:1440, 1:90, 921:1104)  (1351:1440, 91:180, 921:1104)  …  (1351:1440, 631:720, 921:1104)

[:, :, 7] =
 (1:90, 1:90, 1105:1288)       (1:90, 91:180, 1105:1288)       …  (1:90, 631:720, 1105:1288)
 (91:180, 1:90, 1105:1288)     (91:180, 91:180, 1105:1288)        (91:180, 631:720, 1105:1288)
 (181:270, 1:90, 1105:1288)    (181:270, 91:180, 1105:1288)       (181:270, 631:720, 1105:1288)
 (271:360, 1:90, 1105:1288)    (271:360, 91:180, 1105:1288)       (271:360, 631:720, 1105:1288)
 (361:450, 1:90, 1105:1288)    (361:450, 91:180, 1105:1288)       (361:450, 631:720, 1105:1288)
 (451:540, 1:90, 1105:1288)    (451:540, 91:180, 1105:1288)    …  (451:540, 631:720, 1105:1288)
 ⋮                                                             ⋱  
 (901:990, 1:90, 1105:1288)    (901:990, 91:180, 1105:1288)    …  (901:990, 631:720, 1105:1288)
 (991:1080, 1:90, 1105:1288)   (991:1080, 91:180, 1105:1288)      (991:1080, 631:720, 1105:1288)
 (1081:1170, 1:90, 1105:1288)  (1081:1170, 91:180, 1105:1288)     (1081:1170, 631:720, 1105:1288)
 (1171:1260, 1:90, 1105:1288)  (1171:1260, 91:180, 1105:1288)     (1171:1260, 631:720, 1105:1288)
 (1261:1350, 1:90, 1105:1288)  (1261:1350, 91:180, 1105:1288)     (1261:1350, 631:720, 1105:1288)
 (1351:1440, 1:90, 1105:1288)  (1351:1440, 91:180, 1105:1288)  …  (1351:1440, 631:720, 1105:1288)

[:, :, 8] =
 (1:90, 1:90, 1289:1472)       (1:90, 91:180, 1289:1472)       …  (1:90, 631:720, 1289:1472)
 (91:180, 1:90, 1289:1472)     (91:180, 91:180, 1289:1472)        (91:180, 631:720, 1289:1472)
 (181:270, 1:90, 1289:1472)    (181:270, 91:180, 1289:1472)       (181:270, 631:720, 1289:1472)
 (271:360, 1:90, 1289:1472)    (271:360, 91:180, 1289:1472)       (271:360, 631:720, 1289:1472)
 (361:450, 1:90, 1289:1472)    (361:450, 91:180, 1289:1472)       (361:450, 631:720, 1289:1472)
 (451:540, 1:90, 1289:1472)    (451:540, 91:180, 1289:1472)    …  (451:540, 631:720, 1289:1472)
 ⋮                                                             ⋱  
 (901:990, 1:90, 1289:1472)    (901:990, 91:180, 1289:1472)    …  (901:990, 631:720, 1289:1472)
 (991:1080, 1:90, 1289:1472)   (991:1080, 91:180, 1289:1472)      (991:1080, 631:720, 1289:1472)
 (1081:1170, 1:90, 1289:1472)  (1081:1170, 91:180, 1289:1472)     (1081:1170, 631:720, 1289:1472)
 (1171:1260, 1:90, 1289:1472)  (1171:1260, 91:180, 1289:1472)     (1171:1260, 631:720, 1289:1472)
 (1261:1350, 1:90, 1289:1472)  (1261:1350, 91:180, 1289:1472)     (1261:1350, 631:720, 1289:1472)
 (1351:1440, 1:90, 1289:1472)  (1351:1440, 91:180, 1289:1472)  …  (1351:1440, 631:720, 1289:1472)

[:, :, 9] =
 (1:90, 1:90, 1473:1656)       (1:90, 91:180, 1473:1656)       …  (1:90, 631:720, 1473:1656)
 (91:180, 1:90, 1473:1656)     (91:180, 91:180, 1473:1656)        (91:180, 631:720, 1473:1656)
 (181:270, 1:90, 1473:1656)    (181:270, 91:180, 1473:1656)       (181:270, 631:720, 1473:1656)
 (271:360, 1:90, 1473:1656)    (271:360, 91:180, 1473:1656)       (271:360, 631:720, 1473:1656)
 (361:450, 1:90, 1473:1656)    (361:450, 91:180, 1473:1656)       (361:450, 631:720, 1473:1656)
 (451:540, 1:90, 1473:1656)    (451:540, 91:180, 1473:1656)    …  (451:540, 631:720, 1473:1656)
 ⋮                                                             ⋱  
 (901:990, 1:90, 1473:1656)    (901:990, 91:180, 1473:1656)    …  (901:990, 631:720, 1473:1656)
 (991:1080, 1:90, 1473:1656)   (991:1080, 91:180, 1473:1656)      (991:1080, 631:720, 1473:1656)
 (1081:1170, 1:90, 1473:1656)  (1081:1170, 91:180, 1473:1656)     (1081:1170, 631:720, 1473:1656)
 (1171:1260, 1:90, 1473:1656)  (1171:1260, 91:180, 1473:1656)     (1171:1260, 631:720, 1473:1656)
 (1261:1350, 1:90, 1473:1656)  (1261:1350, 91:180, 1473:1656)     (1261:1350, 631:720, 1473:1656)
 (1351:1440, 1:90, 1473:1656)  (1351:1440, 91:180, 1473:1656)  …  (1351:1440, 631:720, 1473:1656)

[:, :, 10] =
 (1:90, 1:90, 1657:1840)       (1:90, 91:180, 1657:1840)       …  (1:90, 631:720, 1657:1840)
 (91:180, 1:90, 1657:1840)     (91:180, 91:180, 1657:1840)        (91:180, 631:720, 1657:1840)
 (181:270, 1:90, 1657:1840)    (181:270, 91:180, 1657:1840)       (181:270, 631:720, 1657:1840)
 (271:360, 1:90, 1657:1840)    (271:360, 91:180, 1657:1840)       (271:360, 631:720, 1657:1840)
 (361:450, 1:90, 1657:1840)    (361:450, 91:180, 1657:1840)       (361:450, 631:720, 1657:1840)
 (451:540, 1:90, 1657:1840)    (451:540, 91:180, 1657:1840)    …  (451:540, 631:720, 1657:1840)
 ⋮                                                             ⋱  
 (901:990, 1:90, 1657:1840)    (901:990, 91:180, 1657:1840)    …  (901:990, 631:720, 1657:1840)
 (991:1080, 1:90, 1657:1840)   (991:1080, 91:180, 1657:1840)      (991:1080, 631:720, 1657:1840)
 (1081:1170, 1:90, 1657:1840)  (1081:1170, 91:180, 1657:1840)     (1081:1170, 631:720, 1657:1840)
 (1171:1260, 1:90, 1657:1840)  (1171:1260, 91:180, 1657:1840)     (1171:1260, 631:720, 1657:1840)
 (1261:1350, 1:90, 1657:1840)  (1261:1350, 91:180, 1657:1840)     (1261:1350, 631:720, 1657:1840)
 (1351:1440, 1:90, 1657:1840)  (1351:1440, 91:180, 1657:1840)  …  (1351:1440, 631:720, 1657:1840)
````

