### PR TITLE
Check for zero length index in copyto! and same length of the indices

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -69,7 +69,6 @@ function _copyto!(dest, Rdest, src, Rsrc)
 
     if any(==(0), size(Rdest))
         # This check is here to catch #168
-        println("Return dest")
         return dest
     end
     view(dest, Rdest) .= view(src, Rsrc)

--- a/src/array.jl
+++ b/src/array.jl
@@ -61,8 +61,19 @@ function _copyto!(dest::AbstractArray, source::AbstractArray)
     reshape(dest, size(source)) .= source
     return dest
 end
-_copyto!(dest, Rdest, src, Rsrc) = view(dest, Rdest) .= view(src, Rsrc)
 
+function _copyto!(dest, Rdest, src, Rsrc)
+    if size(Rdest) != size(Rsrc)
+        throw(ArgumentError("source and destination must have same size (got $(size(Rsrc)) and $(size(Rdest)))"))
+    end
+
+    if any(==(0), size(Rdest))
+        # This check is here to catch #168
+        println("Return dest")
+        return dest
+    end
+    view(dest, Rdest) .= view(src, Rsrc)
+end
 # Use a view for lazy reverse
 _reverse(a, ::Colon) = _reverse(a, ntuple(identity, ndims(a)))
 _reverse(a, dims::Int) = _reverse(a, (dims,))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -663,6 +663,12 @@ end
         copyto!(x, a_disk)
         @test x == a
         copyto!(x, CartesianIndices((1:3, 1:2)), a_disk, CartesianIndices((8:10, 8:9)))
+        # Test copyto! with zero length index
+        x_empty = Matrix{Int64}(undef, 0,2)
+        copyto!(x_empty, CartesianIndices((1:0, 1:2)), a_disk, CartesianIndices((8:7, 8:9)))
+        # copyto! with different length should throw an error
+        @test_throws ArgumentError copyto!(x, CartesianIndices((1:1, 1:2)), a_disk, CartesianIndices((4:6, 8:9)))
+
     end
 
     @test collect(reverse(a_disk)) == reverse(a)


### PR DESCRIPTION
This checks for an index of length zero in the copyto! call so that it does not run into chunking issues further down the code. 
I am not entirely sure, whether this is the best spot to introduce this, but it seems to work. 


The check for the same length of the indices is copied from the behaviour of copyto! on normal arrays.
This will fix #168.