### PR TITLE
use indexing rather than broadcast in Array

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -47,9 +47,8 @@ macro implement_array_methods(t)
 end
 
 # Use broadcast to copy to a new Array
-function _Array(a::AbstractArray{T,N}) where {T,N}
-    a[ntuple(_ -> :, Val{N}())...]
-end
+_Array(a::AbstractArray{T,N}) where {T,N} = a[ntuple(_ -> :, Val{N}())...]
+_Array(a::AbstractArray{T,0}) where {T} = fill(a[])
 
 # Use broadcast to copy
 function _copyto!(dest::AbstractArray{<:Any,N}, source::AbstractArray{<:Any,N}) where {N}

--- a/src/array.jl
+++ b/src/array.jl
@@ -47,9 +47,7 @@ end
 
 # Use broadcast to copy to a new Array
 function _Array(a::AbstractArray{T,N}) where {T,N}
-    dest = Array{T,N}(undef, size(a))
-    dest .= a
-    return dest
+    a[ntuple(_ -> :, Val{N}())...]
 end
 
 # Use broadcast to copy

--- a/src/array.jl
+++ b/src/array.jl
@@ -3,6 +3,7 @@ macro implement_array_methods(t)
     t = esc(t)
     quote
         Base.Array(a::$t) = $_Array(a)
+        Base.collect(a::$t) = $_Array(a)
         Base.copyto!(dest::$t, source::AbstractArray) = $_copyto!(dest, source)
         Base.copyto!(dest::AbstractArray, source::$t) = $_copyto!(dest, source)
         Base.copyto!(dest::$t, source::$t) = $_copyto!(dest, source)


### PR DESCRIPTION
This MWE is with DiskArrays.jl devved on to latest master

```julia
using BenchmarkTools
using ArchGDAL
using Rasters

fn = "deleteme.tif"
x = X(1:4096)
y = Y(1:4096)
bs = 256 # block size
rs = 512 # read size
write(fn, Raster(rand(UInt8, x,y)); options=Dict("TILED"=>"YES", "BLOCKXSIZE"=>bs, "BLOCKYSIZE"=>bs), force=true)

ext = Rasters.Extents.Extent(X=(1, rs), Y=(1, rs))
nt = (min_x=1, min_y=1, max_x=rs, max_y=rs)

r = Raster(fn; lazy=true)
v = Rasters.view(r, ext)
```

We can time indexing is 3x faster than calling `Array`. Im not really sure why.
```julia
julia> @btime $v[:, :];
  118.211 μs (130 allocations: 261.72 KiB)

julia> @btime Array($v);
  492.226 μs (518 allocations: 533.95 KiB)
```

This PR just switches `Array` over to index with all `:`. so the timings are:

```julia
julia> @btime $v[:, :];
@btime Array($v);
  118.788 μs (130 allocations: 261.72 KiB)

julia> @btime Array($v);
  123.338 μs (106 allocations: 261.42 KiB)
```

(To me this also suggest there is something wrong with our broadcasts... broadcast to a regular array should be almost identical to indexing the whole array, but instead its 3-4x slower)