### PR TITLE
Fix undef writes in setindex take 2

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -526,6 +526,14 @@ end
     b[mask] = fill(2.0, 4)
     @test_broken setindex_count(b) == 4
 
+    b = AccessCountDiskArray(zeros(4, 5, 1); chunksize=(4, 1, 1), batchstrategy=ChunkRead())
+    b[1:2:4, 1] = [1, 2]
+    @test b.parent[1:2:4, 1] == [1, 2]
+
+    b = AccessCountDiskArray(zeros(4, 5, 1); chunksize=(4, 1, 1), batchstrategy=DiskArrays.SubRanges(CanStepRange(), 1.0))
+    b[1:2:4, 1] = [1, 2]
+    @test b.parent[1:2:4, 1] == [1, 2]
+
     #Test for #131
     a = reshape(1:75,5,5,3)
     a1 = AccessCountDiskArray(a);


### PR DESCRIPTION
Supersedes #172 . 

Actually there were multiple thing going on in this 

1. Broken dispatch that led to setindex not using passing a steprange to writeblock although NCDatasets indicates its capacity to process these by setting `CanStepRange`
2. Sending undefined data to getindex. It was very lucky that you included a test with Strings, for other data types the error was there as well but did not surface because these undef arrays are filled with garbage data then. This is fixed now. 

