### PR TITLE
Add ChunkTiledDiskArray abstract type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiskArrays"
 uuid = "3c3547ce-8d99-4f5e-a174-61eb10b00ae3"
 authors = ["Fabian Gans <fgans@bgc-jena.mpg.de>"]
-version = "0.4.4"
+version = "0.4.5"
 
 [deps]
 LRUCache = "8ac3fa9e-de4c-5943-b1dc-09c6b5f20637"


### PR DESCRIPTION
This PR adds `ChunkTiledDiskArray`, another abstract supertype to build DiskArrays from. For this one, the interface is a bit different, namely that instead of defining `readblock!` a method for `Base.getindex(a,i::ChunkIndex)` must be defined. This is very handy for array that are just a lazy concatentation of blocks or tiles where each block represents a chunk of the array, so chunking and reading are closely related. Currently these arrays are read-only, as we don't define `setindex!` for `ChunkIndex` types yet, but would be the next step. 

As a proof of concept, the already existing `CachedDiskArray` is now built on top of this new abstract type, since the cache is queried chunk by chunk. 