### PR TITLE
Fix dispatch for mapreduce

### DIFF
--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -4,7 +4,7 @@
 macro implement_mapreduce(t)
     t = esc(t)
     quote
-        function Base._mapreduce(f, op, v::$t)
+        function Base._mapreduce(f, op, ::IndexCartesian, v::$t)
             mapreduce(op, eachchunk(v)) do cI
                 a = v[to_ranges(cI)...]
                 mapreduce(f, op, a)


### PR DESCRIPTION
This fixes the mapreduce dispatch where things like `sum(DA)` were not hitting the correct mapreduce methods but computed through an iteration fallback. I will add a unit test to facilitate detecting this in the future, probably one involving Float32 summation as in #188 to make sure results are accumulated block-wise. 