### PR TITLE
Attempt to add support for `getindex(::DiskArray, Int[])`

### DIFF
--- a/src/batchgetindex.jl
+++ b/src/batchgetindex.jl
@@ -60,6 +60,7 @@ end
 
 function has_chunk_gap(cs,ids::AbstractVector{<:Integer})
     #Find largest jump in indices
+    isempty(ids) && return false
     minind,maxind = extrema(ids)
     maxind - minind > first(cs)
 end
@@ -67,7 +68,9 @@ end
 has_chunk_gap(cs,ids) = true
 
 #Compute the number of possible indices in the hyperrectangle
-span(v::AbstractArray{<:Integer}) = 1 -(-(extrema(v)...))
+function span(v::AbstractArray{<:Integer})
+    iszero(length(v)) ? 0 : 1 -(-(extrema(v)...))
+end
 function span(v::AbstractArray{CartesianIndex{N}}) where N
     minind,maxind = extrema(v)
     prod((maxind-minind+oneunit(minind)).I)

--- a/src/diskarray.jl
+++ b/src/diskarray.jl
@@ -144,7 +144,8 @@ end
 function process_index(i::AbstractArray{<:CartesianIndex{N}}, cs, ::NoBatch) where {N}
     csnow, csrem = splitcs(i, cs)
     s = arraysize_from_chunksize.(csnow)
-    cindmin, cindmax = extrema(view(CartesianIndices(s), i))
+    v = view(CartesianIndices(s), i)
+    cindmin, cindmax = extrema(v;init=(CartesianIndex(),CartesianIndex()))
     indmin, indmax = cindmin.I, cindmax.I
     tempsize = indmax .- indmin .+ 1
     tempoffset = cindmin - oneunit(cindmin)
@@ -157,7 +158,7 @@ function process_index(i::CartesianIndices{N}, cs, ::NoBatch) where {N}
     cols = map(_ -> Colon(), i.indices)
     DiskIndex(length.(i.indices), length.(i.indices), cols, cols, i.indices), csrem
 end
-splitcs(i::AbstractArray{<:CartesianIndex}, cs) = splitcs(first(i).I, (), cs)
+splitcs(i::AbstractArray{<:CartesianIndex}, cs) = isempty(i) ? splitcs((), cs) : splitcs(first(i).I, (), cs)
 splitcs(i::AbstractArray{Bool}, cs) = splitcs(size(i), (), cs)
 splitcs(i::CartesianIndices, cs) = splitcs(i.indices, (), cs)
 splitcs(i::CartesianIndex, cs) = splitcs(i.I,(),cs)

--- a/src/diskarray.jl
+++ b/src/diskarray.jl
@@ -145,7 +145,11 @@ function process_index(i::AbstractArray{<:CartesianIndex{N}}, cs, ::NoBatch) whe
     csnow, csrem = splitcs(i, cs)
     s = arraysize_from_chunksize.(csnow)
     v = view(CartesianIndices(s), i)
-    cindmin, cindmax = extrema(v;init=(CartesianIndex(),CartesianIndex()))
+    cindmin, cindmax = if isempty(v)
+       one(CartesianIndex{N}), zero(CartesianIndex{N}) 
+    else
+        extrema(v)
+    end
     indmin, indmax = cindmin.I, cindmax.I
     tempsize = indmax .- indmin .+ 1
     tempoffset = cindmin - oneunit(cindmin)
@@ -158,7 +162,7 @@ function process_index(i::CartesianIndices{N}, cs, ::NoBatch) where {N}
     cols = map(_ -> Colon(), i.indices)
     DiskIndex(length.(i.indices), length.(i.indices), cols, cols, i.indices), csrem
 end
-splitcs(i::AbstractArray{<:CartesianIndex}, cs) = isempty(i) ? splitcs((), cs) : splitcs(first(i).I, (), cs)
+splitcs(i::AbstractArray{<:CartesianIndex}, cs) = splitcs(one(eltype(i)).I, (), cs)
 splitcs(i::AbstractArray{Bool}, cs) = splitcs(size(i), (), cs)
 splitcs(i::CartesianIndices, cs) = splitcs(i.indices, (), cs)
 splitcs(i::CartesianIndex, cs) = splitcs(i.I,(),cs)

--- a/src/diskarray.jl
+++ b/src/diskarray.jl
@@ -238,13 +238,13 @@ function getindex_disk_nobatch!(out,a,i)
     outputarray = create_outputarray(out, a, indices.output_size)
     outalias = output_aliasing(indices,ndims(outputarray),ndims(a))
     if outalias === :identical
-        readblock!(a, outputarray, indices.data_indices...)
+        readblock_sizecheck!(a, outputarray, indices.data_indices...)
     elseif outalias === :reshapeoutput
         temparray = reshape(outputarray,indices.temparray_size)
-        readblock!(a, temparray, indices.data_indices...)
+        readblock_sizecheck!(a, temparray, indices.data_indices...)
     else
         temparray = Array{eltype(a)}(undef, indices.temparray_size...)
-        readblock!(a, temparray, indices.data_indices...)
+        readblock_sizecheck!(a, temparray, indices.data_indices...)
         transfer_results!(outputarray, temparray, indices.output_indices, indices.temparray_indices)
     end
     outputarray
@@ -302,7 +302,7 @@ function setindex_disk_batch!(a,v,i)
             readblock!(a, vtemparray, data_indices...)
             transfer_results_write!(v, temparray, output_indices, temparray_indices)
         end
-        writeblock!(a, vtemparray, data_indices...)
+        writeblock_sizecheck!(a, vtemparray, data_indices...)
     end
 end
 
@@ -310,10 +310,10 @@ function setindex_disk_nobatch!(a,v,i)
     indices = resolve_indices(a, i, NoBatch(batchstrategy(a)))
     outalias = output_aliasing(indices,ndims(a),ndims(v))
     if outalias === :identical
-        writeblock!(a, v, indices.data_indices...)
+        writeblock_sizecheck!(a, v, indices.data_indices...)
     elseif outalias === :reshapeoutput
         temparray = reshape(v,indices.temparray_size)
-        writeblock!(a, temparray, indices.data_indices...)
+        writeblock_sizecheck!(a, temparray, indices.data_indices...)
     else
         temparray = Array{eltype(a)}(undef, indices.temparray_size...)
         if any(ind->is_sparse_index(ind,density_threshold=1.0),indices.temparray_indices)
@@ -324,7 +324,21 @@ function setindex_disk_nobatch!(a,v,i)
             readblock!(a, temparray, indices.data_indices...)
         end
         transfer_results_write!(v, temparray, indices.output_indices, indices.temparray_indices)
-        writeblock!(a, temparray, indices.data_indices...)
+        writeblock_sizecheck!(a, temparray, indices.data_indices...)
+    end
+end
+
+"Like `readblock!`, but only exectued when data size to read is not empty"
+function readblock_sizecheck!(x,y,i...)
+    if length(y) > 0
+        readblock!(x,y,i...)
+    end
+end
+
+"Like `writeblock!`, but only exectued when data size to read is not empty"
+function writeblock_sizecheck!(x,y,i...)
+    if length(y) > 0
+        writeblock!(x,y,i...)
     end
 end
 

--- a/src/diskarray.jl
+++ b/src/diskarray.jl
@@ -162,7 +162,7 @@ function process_index(i::CartesianIndices{N}, cs, ::NoBatch) where {N}
     cols = map(_ -> Colon(), i.indices)
     DiskIndex(length.(i.indices), length.(i.indices), cols, cols, i.indices), csrem
 end
-splitcs(i::AbstractArray{<:CartesianIndex}, cs) = splitcs(one(eltype(i)).I, (), cs)
+splitcs(i::AbstractArray{<:CartesianIndex}, cs) = splitcs(oneunit(eltype(i)).I, (), cs)
 splitcs(i::AbstractArray{Bool}, cs) = splitcs(size(i), (), cs)
 splitcs(i::CartesianIndices, cs) = splitcs(i.indices, (), cs)
 splitcs(i::CartesianIndex, cs) = splitcs(i.I,(),cs)

--- a/src/diskarray.jl
+++ b/src/diskarray.jl
@@ -129,7 +129,7 @@ function process_index(i::AbstractUnitRange{<:Integer}, cs, ::NoBatch)
     DiskIndex((length(i),), (length(i),), (Colon(),), (Colon(),), (i,)), Base.tail(cs)
 end
 function process_index(i::AbstractArray{<:Integer}, cs, ::NoBatch)
-    indmin, indmax = extrema(i)
+    indmin, indmax = isempty(i) ? (1,0) : extrema(i)
     DiskIndex(size(i), ((indmax - indmin + 1),), map(_->Colon(),size(i)), ((i .- (indmin - 1)),), (indmin:indmax,)), Base.tail(cs)
 end
 function process_index(i::AbstractArray{Bool,N}, cs, ::NoBatch) where {N}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,6 +36,11 @@ end
     @test a[CartesianIndex(1,2,3)] == 15
 end
 
+@testset "getindex with empty array" begin
+    a = AccessCountDiskArray(reshape(1:24,2,3,4),chunksize=(2,2,2))
+    @test a[Int[]] == Float64[]
+end
+
 function test_getindex(a)
     @test a[2, 3, 1] == 10
     @test a[2, 3] == 10

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -496,6 +496,13 @@ end
     a = AccessCountDiskArray(reshape(1:20, 4, 5, 1); chunksize=(4, 1, 1))
     @test a[:, [1, 4], 1] == trueparent(a)[:, [1, 4], 1]
     @test getindex_count(a) == 1
+
+    #Test with empty vectors
+    @test a[Int[]] == Int[]
+    @test a[:,Int[],:] == zeros(Int,4,0,1)
+    @test a[Int[],:,:] == zeros(Int,0,5,1)
+    @test getindex_count(a) == 4
+
     coords = CartesianIndex.([(1, 1, 1), (3, 1, 1), (2, 4, 1), (4, 4, 1)])
     @test a[coords] == trueparent(a)[coords]
     @test_broken getindex_count(a) == 4

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -501,7 +501,7 @@ end
     @test a[Int[]] == Int[]
     @test a[:,Int[],:] == zeros(Int,4,0,1)
     @test a[Int[],:,:] == zeros(Int,0,5,1)
-    @test getindex_count(a) == 4
+    @test getindex_count(a) == 1
 
     coords = CartesianIndex.([(1, 1, 1), (3, 1, 1), (2, 4, 1), (4, 4, 1)])
     @test a[coords] == trueparent(a)[coords]


### PR DESCRIPTION
Closes #186.

I'm running into some code paths that I'm not sure how to fix. The current error (in the added test suite) is:

```julia
julia> a[Int[]]
ERROR: ArgumentError: Indices can only be omitted for trailing singleton dimensions
Stacktrace:
 [1] _resolve_indices
   @ ~/Dropbox/Caltech/work/dev/clones/forks/DiskArrays.jl/src/diskarray.jl:111 [inlined]
 [2] _resolve_indices
   @ ~/Dropbox/Caltech/work/dev/clones/forks/DiskArrays.jl/src/diskarray.jl:97 [inlined]
 [3] resolve_indices
   @ ~/Dropbox/Caltech/work/dev/clones/forks/DiskArrays.jl/src/diskarray.jl:44 [inlined]
 [4] resolve_indices(a::AccessCountDiskArray{…}, i::Tuple{…}, batchstrategy::DiskArrays.NoBatch{…})
   @ DiskArrays ~/Dropbox/Caltech/work/dev/clones/forks/DiskArrays.jl/src/diskarray.jl:51
 [5] getindex_disk_nobatch!(out::Nothing, a::AccessCountDiskArray{…}, i::Tuple{…})
   @ DiskArrays ~/Dropbox/Caltech/work/dev/clones/forks/DiskArrays.jl/src/diskarray.jl:233
 [6] getindex_disk!(out::Nothing, a::AccessCountDiskArray{…}, i::Vector{…})
   @ DiskArrays ~/Dropbox/Caltech/work/dev/clones/forks/DiskArrays.jl/src/diskarray.jl:254
 [7] getindex_disk
   @ ~/Dropbox/Caltech/work/dev/clones/forks/DiskArrays.jl/src/diskarray.jl:214 [inlined]
 [8] getindex(a::AccessCountDiskArray{Int64, 3, Base.ReshapedArray{…}, DiskArrays.ChunkRead{…}}, i::Vector{Int64})
   @ DiskArrays ~/Dropbox/Caltech/work/dev/clones/forks/DiskArrays.jl/src/diskarray.jl:352
 [9] top-level scope
   @ REPL[23]:1
Some type information was truncated. Use `show(err)` to see complete types.
```

Can someone offer some tips? @rafaqz / @meggart ?