### PR TITLE
Update #189

### DIFF
--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -47,3 +47,14 @@ macro implement_mapreduce(t)
         end
     end
 end
+
+
+# optimized implementation for special cases
+
+for fname in [:sum,:prod,:count,:all,:any,:minimum,:maximum]
+    @eval function Base.$fname(v::AbstractDiskArray)
+        $fname(eachchunk(v)) do chunk
+            $fname(v[chunk...])
+        end
+    end
+end

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -49,12 +49,18 @@ macro implement_mapreduce(t)
 end
 
 
-# optimized implementation for special cases
+# Implementation for special cases for special cases and if fallback breaks in future julia versions
 
-for fname in [:sum,:prod,:count,:all,:any,:minimum,:maximum]
-    @eval function Base.$fname(v::AbstractDiskArray)
+for fname in [:sum,:prod,:all,:any,:minimum,:maximum]
+    @eval function Base.$fname(f, v::AbstractDiskArray)
         $fname(eachchunk(v)) do chunk
-            $fname(v[chunk...])
+            $fname(f,v[chunk...])
         end
+    end
+end
+
+function Base.count(f,v::AbstractDiskArray)
+    sum(eachchunk(v)) do chunk
+        count(f,v[chunk...])
     end
 end

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -52,7 +52,7 @@ end
 # Implementation for special cases for special cases and if fallback breaks in future julia versions
 
 for fname in [:sum,:prod,:all,:any,:minimum,:maximum]
-    @eval function Base.$fname(f, v::AbstractDiskArray)
+    @eval function Base.$fname(f::Function, v::AbstractDiskArray)
         $fname(eachchunk(v)) do chunk
             $fname(f,v[chunk...])
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -907,7 +907,20 @@ end
     @test getindex_count(A) == 0 
 end
 
+@testset "optimization for associative reductions" begin
+    A = rand(1:10,30,30)
+    DA = AccessCountDiskArray(A,chunksize=(2,2))
 
+    for fun in (sum, prod, maximum, minimum)
+        @test fun(A) == fun(DA)
+    end
+
+    Ab = rand(Bool,30,30)
+    DAb = AccessCountDiskArray(Ab,chunksize=(2,2))
+    for fun in (count, all, any)
+        @test fun(Ab) == fun(DAb)
+    end
+end
 
 # @test offsets    == [[1:1,2:3,4:4],[5:5,6:6,7:7],[8:8,9:9]]
 # inds = [1,1,1,3,5,6,6,7,10,13,16,16,19,20]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -333,6 +333,19 @@ import Statistics: mean
 @testset "Reductions" begin
     a = data -> AccessCountDiskArray(data; chunksize=(5, 4, 2))
     test_reductions(a)
+
+    @testset "Early stopping for all and any" begin
+        a = trues(10)
+        b = falses(10)
+        da = AccessCountDiskArray(a, chunksize=(2,))
+        db = AccessCountDiskArray(b, chunksize=(2,))
+        @test any(da)
+        @test any(==(true),da)
+        @test !all(db)
+        @test !all(==(true),db)
+        @test getindex_count(da)==2
+        @test getindex_count(db)==2
+    end
 end
 
 @testset "Broadcast" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -116,9 +116,11 @@ function test_reductions(af)
     for f in (
         minimum,
         maximum,
+        prod,
         sum,
         (i, args...; kwargs...) -> all(j -> j > 0.1, i, args...; kwargs...),
         (i, args...; kwargs...) -> any(j -> j < 0.1, i, args...; kwargs...),
+        (i, args...; kwargs...) -> count(j -> j < 0.1, i, args...; kwargs...),
         (i, args...; kwargs...) -> mapreduce(x -> 2 * x, +, i, args...; kwargs...),
     )
         a = af(data)
@@ -907,23 +909,3 @@ end
     @test getindex_count(A) == 0 
 end
 
-@testset "optimization for associative reductions" begin
-    A = rand(1:10,30,30)
-    DA = AccessCountDiskArray(A,chunksize=(2,2))
-
-    for fun in (sum, prod, maximum, minimum)
-        @test fun(A) == fun(DA)
-    end
-
-    Ab = rand(Bool,30,30)
-    DAb = AccessCountDiskArray(Ab,chunksize=(2,2))
-    for fun in (count, all, any)
-        @test fun(Ab) == fun(DAb)
-    end
-end
-
-# @test offsets    == [[1:1,2:3,4:4],[5:5,6:6,7:7],[8:8,9:9]]
-# inds = [1,1,1,3,5,6,6,7,10,13,16,16,19,20]
-# readranges, offsets = find_subranges_sorted(inds,false)
-# @test readranges == [1:1, 3:3, 5:7, 10:10, 13:13, 16:16, 19:20]
-# @test offsets == [[1:3], [4:4], [5:5,6:7,8:8], [9:9], [10:10], [11:12], [13:13,14:14]]


### PR DESCRIPTION
This is a rebased and slightly modified version of #189 . It keeps the optimized versions for some special reduction functions, and adding a test to check at least for `any` and `all` that early escape is happening.  