### PR TITLE
Add a DiskIndex constructor to fix 32bit systems

### DIFF
--- a/src/diskarray.jl
+++ b/src/diskarray.jl
@@ -90,6 +90,9 @@ end
         (a.data_indices...,b.data_indices...),
     )
 end
+DiskIndex(output_size::NTuple{N,<:Integer},temparray_size::NTuple{M,<:Integer}, 
+    output_indices::Tuple,temparray_indices::Tuple,data_indices::Tuple) where {N, M} = 
+        DiskIndex(Int.(output_size),Int.(temparray_size),output_indices,temparray_indices,data_indices)
 
 function _resolve_indices(cs, i, indices_pre::DiskIndex, nb::ChunkStrategy)
     inow = first(i)


### PR DESCRIPTION
Thanks @Alexander-Barth for the fix needed for https://github.com/Alexander-Barth/NCDatasets.jl/pull/247 which I copy-pasted into this PR. 