### PR TITLE
display warning (Can not determine size of element type...) only once

### DIFF
--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -351,7 +351,7 @@ function element_size(a::AbstractArray)
     elseif isbitstype(Base.nonmissingtype(eltype(a)))
         return sizeof(Base.nonmissingtype(eltype(a)))
     else
-        @warn "Can not determine size of element type. Using DiskArrays.fallback_element_size[] = $(fallback_element_size[]) bytes"
+        @warn "Can not determine size of element type. Using DiskArrays.fallback_element_size[] = $(fallback_element_size[]) bytes" maxlog=1
         return fallback_element_size[]
     end
 end


### PR DESCRIPTION
This PR makes sure that the warning 
```
Warning: Can not determine size of element type. Using DiskArrays.fallback_element_size[] = 100 bytes
```

is displayed only once. The warning is triggered quite often in NCDatastes' tests (for strings and variable-length arrays of different type).