### PR TITLE
drop isdisk definition on AbstractDiskArray

### DIFF
--- a/src/diskarray.jl
+++ b/src/diskarray.jl
@@ -14,7 +14,6 @@ Return `true` if `a` is a `AbstractDiskArray` or follows
 the DiskArrays.jl interface via macros. Otherwise `false`.
 """
 isdisk(a::AbstractArray) = isdisk(typeof(a))
-isdisk(::Type{<:AbstractDiskArray}) = true
 isdisk(::Type{<:AbstractArray}) = false
 
 """


### PR DESCRIPTION
Reverse a bug introduced by https://github.com/JuliaIO/DiskArrays.jl/pull/221. `isdisk` is defined twice for AbstractDiskArray (directly and because the implement_getindex macro is called), which affects precompilation