### PR TITLE
only call `sizeof` on isbits types

### DIFF
--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -64,8 +64,7 @@ function common_chunks(s, args...)
     if isempty(chunkedarrays)
         # Estimate chunk size for isbits
         if all(map(isbits ∘ eltype, args))
-            totalsize = sum(sizeof ∘ eltype, args)
-            return estimate_chunksize(s, totalsize)
+            return estimate_chunksize(s)
         else # Otherwise just use one huge chunk, we dont know what the object is
             return GridChunks(s, s)
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1116,3 +1116,8 @@ end
     @inferred DiskArrays.DiskIndex(a_view5, (1:1, 1:1, 1:1, 1:1, 1:1), DiskArrays.NoBatch()) #DiskArrays.DiskIndex
     @inferred DiskArrays.DiskIndex(a_view6, (1:1, 1:1, 1:1, 1:1, 1:1, 1:1), DiskArrays.NoBatch()) #DiskArrays.DiskIndex
 end
+
+@testset "test broadcast over strings" begin
+    a = UnchunkedDiskArray(["a", "b", "c"])
+    @test all(a .== ["a", "b", "c"])
+end


### PR DESCRIPTION
This currently fails for `String`, and will for any other non-isbits type

This PR adds another path for non-isbits types in broadcast that just treats the whole array as one chunk.

Closes #261