### PR TITLE
Fix setindex of FillArray view

### DIFF
--- a/src/batchgetindex.jl
+++ b/src/batchgetindex.jl
@@ -108,6 +108,9 @@ end
 numind(a::AbstractArray{Bool}) = sum(a)
 numind(a::Union{AbstractArray{<:Integer},AbstractArray{<:CartesianIndex}}) = length(a)
 
+# a view on a FillArray has non-numerical ids
+is_sparse_index(ids::Colon; density_threshold=0.5) = false
+
 function is_sparse_index(ids; density_threshold=0.5)
     indexdensity = numind(ids) / span(ids)
     return indexdensity < density_threshold


### PR DESCRIPTION
This PR aims to fix an error when it comes to write a subset of an `DiskArray` initialized by a `FillArray` using a view.
In [DGGS.jl](https://github.com/danlooo/DGGS.jl), we initialize a global raster array with a `FillArray`. Then, we subset a local region using `view`. However, a `MethodError` is thrown when we want to write into that entire view:

````julia
using DiskArrays
using YAXArrays
using DimensionalData
using Zarr
using FillArrays

path = tempname() * ".zarr"
a = Zeros(Float64, (10, 20)) |> YAXArray
ds = Dataset(layer=a)
savedataset(ds; path=path)
ds = open_dataset(zopen(path, "w"))
a = view(ds.layer; Dim_1=At([1]))
a .= fill(42, size(a))
````

results in 

```

ERROR: MethodError: no method matching numind(::Colon)
The function `numind` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  numind(::AbstractArray{Bool})
   @ DiskArrays ~/.julia/dev/DiskArrays/src/batchgetindex.jl:108
  numind(::Union{AbstractArray{<:Integer}, AbstractArray{<:CartesianIndex}})
   @ DiskArrays ~/.julia/dev/DiskArrays/src/batchgetindex.jl:109

Stacktrace:
  [1] is_sparse_index(ids::Function; density_threshold::Float64)
    @ DiskArrays ~/.julia/dev/DiskArrays/src/batchgetindex.jl:115
  [2] (::DiskArrays.var"#setindex_disk_nobatch!##0#setindex_disk_nobatch!##1")(ind::Function)
    @ DiskArrays ~/.julia/dev/DiskArrays/src/indexing.jl:186
  [3] _any_tuple
    @ ./anyall.jl:146 [inlined]
  [4] _any_tuple
    @ ./anyall.jl:152 [inlined]
  [5] any
    @ ./anyall.jl:142 [inlined]
  [6] setindex_disk_nobatch!(a::ZArray{…}, values::Matrix{…}, i::Tuple{…})
    @ DiskArrays ~/.julia/dev/DiskArrays/src/indexing.jl:186
  [7] setindex_disk!(::ZArray{…}, ::Matrix{…}, ::Vector{…}, ::Vararg{…})
    @ DiskArrays ~/.julia/dev/DiskArrays/src/indexing.jl:137
  [8] writeblock!(::DiskArrays.SubDiskArray{…}, ::Matrix{…}, ::UnitRange{…}, ::Vararg{…})
    @ DiskArrays ~/.julia/dev/DiskArrays/src/subarray.jl:38
  [9] writeblock_checked!
    @ ~/.julia/dev/DiskArrays/src/indexing.jl:301 [inlined]
 [10] setindex_disk_nobatch!(a::DiskArrays.SubDiskArray{…}, values::Matrix{…}, i::Tuple{…})
    @ DiskArrays ~/.julia/dev/DiskArrays/src/indexing.jl:178
 [11] setindex_disk!
    @ ~/.julia/dev/DiskArrays/src/indexing.jl:137 [inlined]
 [12] setindex!
    @ ~/.julia/dev/DiskArrays/src/indexing.jl:324 [inlined]
 [13] #159
    @ ~/.julia/dev/DiskArrays/src/broadcast.jl:156 [inlined]
 [14] foreach(f::DiskArrays.var"#159#160"{…}, itr::DiskArrays.GridChunks{…})
    @ Base ./abstractarray.jl:3188
 [15] copyto!
    @ ~/.julia/dev/DiskArrays/src/broadcast.jl:154 [inlined]
 [16] copyto!
    @ ./broadcast.jl:947 [inlined]
 [17] materialize!
    @ ./broadcast.jl:905 [inlined]
 [18] materialize!(dest::YAXArray{…}, bc::Base.Broadcast.Broadcasted{…})
    @ DimensionalData ~/.julia/packages/DimensionalData/MRS45/src/array/broadcast.jl:94
 [19] top-level scope
    @ REPL[12]:1
Some type information was truncated. Use `show(err)` to see complete types.
```

This is because `:` slices have an undefined length. We can fix this e.g. by setting `is_sparse_index` to `false` for this case. Does this have other implications?