### PR TITLE
Call `checkbounds` also when using non-scalar indexing

### DIFF
--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -62,6 +62,7 @@ getindex_disk(a::AbstractArray, i::ChunkIndex{<:Any,OffsetChunks}) =
     wrapchunk(a[nooffset(i)], eachchunk(a)[i.I])
 
 function getindex_disk!(out::Union{Nothing,AbstractArray}, a::AbstractArray, i...)
+    checkbounds(a, i...)
     # Check if we can write once or need to use multiple batches
     if need_batch(a, i)
         getindex_disk_batch!(out, a, i)

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -30,7 +30,6 @@ Converts indices to ranges and calls `DiskArrays.readblock!`
 """
 function getindex_disk(a::AbstractArray, i::Union{Integer,CartesianIndex}...)
     checkscalar(a, i)
-    checkbounds(a, i...)
     # Use a 1 x 1 block
     outputarray = Array{eltype(a)}(undef, map(_ -> 1, size(a))...)
     i = Base.to_indices(a, i)
@@ -62,7 +61,6 @@ getindex_disk(a::AbstractArray, i::ChunkIndex{<:Any,OffsetChunks}) =
     wrapchunk(a[nooffset(i)], eachchunk(a)[i.I])
 
 function getindex_disk!(out::Union{Nothing,AbstractArray}, a::AbstractArray, i...)
-    checkbounds(a, i...)
     # Check if we can write once or need to use multiple batches
     if need_batch(a, i)
         getindex_disk_batch!(out, a, i)
@@ -310,7 +308,12 @@ macro implement_getindex(t)
     t = esc(t)
     quote
         DiskArrays.isdisk(::Type{<:$t}) = true
-        Base.getindex(a::$t, i...) = getindex_disk(a, i...)
+        
+        Base.@propagate_inbounds function Base.getindex(a::$t, i...) 
+            Base.@boundscheck checkbounds(a, i...)
+            return getindex_disk(a, i...)
+        end
+
         function DiskArrays.ChunkIndices(a::$t; offset=false)
             return ChunkIndices(
                 map(s -> 1:s, size(eachchunk(a))), offset ? OffsetChunks() : OneBasedChunks()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -83,6 +83,14 @@ function test_getindex(a)
     @test a[2:2:4, 1:2:5] == [2 10 18; 4 12 20]
     @test a[2:2:4, 1:2:5] == [2 10 18; 4 12 20]
     @test a[[1, 3, 4], [1, 3], 1] == [1 9; 3 11; 4 12]
+    @testset "boundscheck" begin
+        # size(a) (4,5,1)
+        @test_throws BoundsError a[6, 1, 1]
+        @test_throws BoundsError a[1, :, 99]
+        @test_throws BoundsError a[1, 1:2:99, 1]
+        @test_throws BoundsError a[CartesianIndex(2, 99), 1]
+        @test_throws BoundsError a[[1, 99], [1, 2], 1] 
+    end
     @testset "allowscalar" begin
         DiskArrays.allowscalar(false)
         @test_throws ErrorException a[2, 3, 1]


### PR DESCRIPTION
This will also call `checkbounds` when using get index with slices, ranges etc. Previous the `checkbounds` where only called when doing scalar indexing. 

I think the missing `checkbounds` is a bug but there is a risk that some package might have used it as a feature.