### PR TITLE
Test and fix indexing with Chunkindex type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiskArrays"
 uuid = "3c3547ce-8d99-4f5e-a174-61eb10b00ae3"
 authors = ["Fabian Gans <fgans@bgc-jena.mpg.de>"]
-version = "0.4.20"
+version = "0.4.21"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"

--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -414,7 +414,7 @@ end
 Base.size(i::ChunkIndices) = length.(i.I)
 Base.getindex(A::ChunkIndices{N}, I::Vararg{Int,N}) where {N} =
     ChunkIndex(CartesianIndex(getindex.(A.I, I)), A.chunktype)
-Base.eltype(::Type{<:ChunkIndices{N}}) where {N} = ChunkIndex{N}
+Base.eltype(::Type{<:ChunkIndices{N,<:Any,O}}) where {N,O} = ChunkIndex{N,O}
 
 """
     element_size(a::AbstractArray)

--- a/src/diskarray.jl
+++ b/src/diskarray.jl
@@ -49,3 +49,7 @@ Returns a trait for the chunk pattern of a dis array,
 """
 function haschunks end
 haschunks(x) = Unchunked()
+
+function Base.checkbounds(::Type{Bool}, a::AbstractDiskArray, i::ChunkIndex)
+    checkbounds(Bool, eachchunk(a), i.I)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using DiskArrays
-using DiskArrays: ReshapedDiskArray, PermutedDiskArray
+using DiskArrays: ReshapedDiskArray, PermutedDiskArray, DiskIndex
 using DiskArrays.TestTypes
 using Test
 using Statistics
@@ -1192,4 +1192,30 @@ end
     a_chunked_2 = DiskArrays.mockchunks(a, (2,2))
     @test DiskArrays.haschunks(a_chunked_2) isa DiskArrays.Chunked
     @test size(DiskArrays.eachchunk(a_chunked_2)) == (5,5)
+end
+
+
+@testset "ChunkIndex" begin
+    data = reshape(1:20, 4, 5)
+    a = AccessCountDiskArray(data, chunksize=(2, 2))
+    a[ChunkIndex(2, 2)] == a[eachchunk(a)[2, 2]...]
+    a[ChunkIndex(2, 3)] == a[eachchunk(a)[2, 3]...]
+    @test_throws BoundsError a[ChunkIndex(0, 1)]
+    @test_throws BoundsError a[ChunkIndex(3, 1)]
+    @test_throws BoundsError a[ChunkIndex(1, 4)]
+
+    chunkinds = ChunkIndices(a)
+    @test size(chunkinds) == (2, 3)
+    @test eltype(chunkinds) == ChunkIndex{2,DiskArrays.OneBasedChunks}
+    @test chunkinds[1, 1] == ChunkIndex(1, 1)
+
+    a_offset = a[ChunkIndex(2, 2, offset=true)]
+    @test a_offset isa DiskArrays.OffsetArray
+    @test size(a_offset) == (2, 2)
+    @test a_offset[3:4, 3:4] == a[3:4, 3:4]
+
+    chunkinds_offset = ChunkIndices(a, offset=true)
+    @test size(chunkinds_offset) == (2, 3)
+    @test eltype(chunkinds_offset) == ChunkIndex{2,DiskArrays.OffsetChunks}
+    @test chunkinds_offset[1, 1] == ChunkIndex(1, 1, offset=true)
 end


### PR DESCRIPTION
This fixes a bug introduced by #296 which was not detected because so far indexing with the `DiskIndex` type was untested. So I added unit tests, fixed the bounds checking for DiskIndex and also an error for eltype on `DiskIndices`.